### PR TITLE
Fixed README.md configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ The configuration might look like this:
   (yas/minor-mode-on)
   (auto-complete-mode 1))
 
-(add-hook 'c++-mode-hook 'sarcasm-enable-ac-and-yas)
+(add-hook 'c++-mode-hook 'my-enable-ac-and-yas)
 (add-hook 'c++-mode-hook 'irony-mode)
-(add-hook 'c-mode-hook 'sarcasm-enable-ac-and-yas)
+(add-hook 'c-mode-hook 'my-enable-ac-and-yas)
 (add-hook 'c-mode-hook 'irony-mode)
 ```
 


### PR DESCRIPTION
hooks referenced wrong function and now reference function used in configuration example.
