### PR TITLE
FindLibClang.cmake: Add generic paths for libclang

### DIFF
--- a/cmake/FindLibClang.cmake
+++ b/cmake/FindLibClang.cmake
@@ -71,6 +71,8 @@ find_library (LibClang_LIBRARY NAMES clang libclang
   /usr/local/Cellar/llvm/3.3/lib
   /usr/local/Cellar/llvm/3.4/lib
   /usr/local/Cellar/llvm/3.5/lib
+  # LLVM Fedora
+  /usr/lib/llvm
   )
 
 set (LibClang_LIBRARIES ${LibClang_LIBRARY})


### PR DESCRIPTION
I added some generic paths for clang's include/lib.
Arch uses /usr/include and /usr/lib.
Fedora uses /usr/include and /usr/lib/llvm.

BTW, I hate that I have to do this but I have an offtopic question:
I liked your emacs theme that you have in the screeshots, can you share it?
