### PR TITLE
Fix a compilation error due to missing header file.

### DIFF
--- a/server/src/support/TemporaryFile.cpp
+++ b/server/src/support/TemporaryFile.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <random>
 
 static std::string getTemporaryFileDirectory() {
   for (const char *envVar : {"TMPDIR", "TMP", "TEMP", "TEMPDIR"}) {


### PR DESCRIPTION
I ran into the following compilation error while building `irony-server` on Mac OS X:

```
[ 16%] Building CXX object src/CMakeFiles/irony-server.dir/support/TemporaryFile.cpp.o
cd /Users/praveek6/.emacs.d/irony/build/src && /opt/clang/bin/clang++   -DCLANG_BUILTIN_HEADERS_DIR=\"/opt/clang/lib/clang/3.4.2/include\" -O3 -DNDEBUG -I/opt/clang/include -I/Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src    -std=c++11 -Wall -Wextra -o CMakeFiles/irony-server.dir/support/TemporaryFile.cpp.o -c /Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp
/Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp:41:10: error: no type named 'random_device' in namespace
      'std'
    std::random_device rd;
    ~~~~~^
/Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp:42:10: error: no member named 'default_random_engine' in
      namespace 'std'
    std::default_random_engine e(rd());
    ~~~~~^
/Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp:60:24: error: use of undeclared identifier 'e'
                     [&e, &dist](char ch) {
                       ^
/Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp:61:52: error: use of undeclared identifier 'e'
        return ch == '%' ? "0123456789abcdef"[dist(e)] : ch;
                                                   ^
In file included from /Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp:9:
In file included from /Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.h:16:
In file included from /opt/clang+llvm-3.4.2-x86_64-apple-darwin10.9/bin/../include/c++/v1/string:439:
/opt/clang+llvm-3.4.2-x86_64-apple-darwin10.9/bin/../include/c++/v1/algorithm:1925:19: error: assigning to 'char' from incompatible type 'void'
        *__result = __op(*__first);
                  ^ ~~~~~~~~~~~~~~
/Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp:57:12: note: in instantiation of function template
      specialization 'std::__1::transform<std::__1::__wrap_iter<char *>, std::__1::__wrap_iter<char *>, <lambda at
      /Users/praveek6/.emacs.d/elpa/irony-20140626.1404/server/src/support/TemporaryFile.cpp:60:22> >' requested here
      std::transform(pattern.begin(),
           ^
5 errors generated.
make[2]: *** [src/CMakeFiles/irony-server.dir/support/TemporaryFile.cpp.o] Error 1
```
