### PR TITLE
Fix Irony::setDebug(false).

### DIFF
--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -33,8 +33,7 @@ public:
 
   /// \brief Set or unset debugging of commands.
   void setDebug(bool enable) {
-    if (enable)
-      debug_ = true;
+    debug_ = enable;
   }
 
   /// \brief Check that a given file with a set of flags compiles.


### PR DESCRIPTION
The previous implementation would refuse to disable debugging. Probably no impact, but at least like this the code corresponds to the comment just above.
