### PR TITLE
Implement "jumping to definition"

### DIFF
--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -152,6 +152,7 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     break;
 
   case Command::Complete:
+  case Command::FindDefinition:
     positionalArgs.push_back(StringConverter(&command_.file));
     positionalArgs.push_back(UnsignedIntConverter(&command_.line));
     positionalArgs.push_back(UnsignedIntConverter(&command_.column));

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -16,6 +16,9 @@ X(Diagnostics, "diagnostics", "FILE - look for diagnostics in file")
 X(Complete,
   "complete",
   "FILE LINE COL - perform code completion at a given location")
+X(FindDefinition,
+  "find-definition",
+  "FILE LINE COL - find the definition of the symbol at a given location")
 X(Help, "help", "show this message")
 X(Exit, "exit", "exit interactive mode, print nothing")
 X(SetDebug, "set-debug", "[on|off] - enable or disable verbose logging")

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -342,3 +342,40 @@ void Irony::complete(const std::string &file,
     std::cout << ")\n";
   }
 }
+
+void Irony::findDefinition(const std::string &file,
+                           unsigned line,
+                           unsigned col,
+                           const std::vector<std::string> &flags,
+                           const std::vector<CXUnsavedFile> &unsavedFiles) {
+
+  CXTranslationUnit tu = tuManager_.getOrCreateTU(file, flags, unsavedFiles);
+
+  if (tu == nullptr) {
+    std::cout << "nil\n";
+    return;
+  }
+
+  // To get the location of the definition, first get the current
+  // CXSourceLocation object. From there we get the cursor of the symbol under
+  // cursor. Next, use clang_getCursorDefinition to get the cursor of the
+  // definition, and get the location of the definition cursor.
+  CXFile f = clang_getFile(tu, file.data());
+  CXSourceLocation location = clang_getLocation(tu, f, line, col);
+  CXCursor cursor = clang_getCursor(tu, location);
+  cursor = clang_getCursorDefinition(cursor);
+  if (clang_Cursor_isNull(cursor)) { // no definition found
+    std::cout << "nil" << std::endl;
+    return;
+  }
+  location = clang_getCursorLocation(cursor);
+
+  clang_getSpellingLocation(location, &f, &line, &col, NULL);
+  CXString file_name = clang_getFileName(f);
+
+  // print the file path, line number, and col number of the definition
+  std::cout << "(\"" << clang_getCString(file_name) << '"' << ' ' <<
+    line << ' ' << col << ')' << std::endl;
+
+  clang_disposeString(file_name);
+}

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -60,6 +60,12 @@ public:
                 unsigned col,
                 const std::vector<std::string> &flags,
                 const std::vector<CXUnsavedFile> &unsavedFiles);
+
+  void findDefinition(const std::string &file,
+                      unsigned line,
+                      unsigned col,
+                      const std::vector<std::string> &flags,
+                      const std::vector<CXUnsavedFile> &unsavedFiles);
   /// @}
 
 private:

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -178,6 +178,10 @@ int main(int ac, const char *av[]) {
       irony.complete(c->file, c->line, c->column, c->flags, c->cxUnsavedFiles);
       break;
 
+    case Command::FindDefinition:
+      irony.findDefinition(c->file, c->line, c->column, c->flags, c->cxUnsavedFiles);
+      break;
+
     case Command::Exit:
       return 0;
 


### PR DESCRIPTION
This is related to #151. I implemented the functionality on irony-server. I think this functionality is fairly easy to implement using clang library, and the implementation is not ugly. The performance may be a bit lower than those indexing versions, but it's not critical -- and it saves time to set up indexing daemons. So, in my opinion, there is no need to wait for another "indexing framework" to implement this.

Usage: irony-server find-definition file-path line col

Output: ("path-to-file-with-definition" line col)
