### PR TITLE
Implement "jumping to declaration" on irony-server.

### DIFF
--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -152,6 +152,7 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     break;
 
   case Command::Complete:
+  case Command::FindDeclaration:
     positionalArgs.push_back(StringConverter(&command_.file));
     positionalArgs.push_back(UnsignedIntConverter(&command_.line));
     positionalArgs.push_back(UnsignedIntConverter(&command_.column));

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -16,6 +16,9 @@ X(Diagnostics, "diagnostics", "FILE - look for diagnostics in file")
 X(Complete,
   "complete",
   "FILE LINE COL - perform code completion at a given location")
+X(FindDeclaration,
+  "find-declaration",
+  "FILE LINE COL - find the declaration of the symbol at a given location")
 X(Help, "help", "show this message")
 X(Exit, "exit", "exit interactive mode, print nothing")
 X(SetDebug, "set-debug", "[on|off] - enable or disable verbose logging")

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -60,6 +60,12 @@ public:
                 unsigned col,
                 const std::vector<std::string> &flags,
                 const std::vector<CXUnsavedFile> &unsavedFiles);
+
+  void findDeclaration(const std::string &file,
+                       unsigned line,
+                       unsigned col,
+                       const std::vector<std::string> &flags,
+                       const std::vector<CXUnsavedFile> &unsavedFiles);
   /// @}
 
 private:

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -178,6 +178,10 @@ int main(int ac, const char *av[]) {
       irony.complete(c->file, c->line, c->column, c->flags, c->cxUnsavedFiles);
       break;
 
+    case Command::FindDeclaration:
+      irony.findDeclaration(c->file, c->line, c->column, c->flags, c->cxUnsavedFiles);
+      break;
+
     case Command::Exit:
       return 0;
 


### PR DESCRIPTION
Jump to the declaration of the symbol on a specific location.

```
Usage: irony-server find-declaration file-path line col

Output: ("path-to-file-with-declaration" line col)
```

Besides it can jump to the definition of some symbols, such as macros, it's also useful to find out which header file contains declaration of a symbol.
