### PR TITLE
Made FindLibClang.cmake resiliant to homebrew llvm updates.

### DIFF
--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -32,7 +32,7 @@ foreach (version ${LIBCLANG_KNOWN_LLVM_VERSIONS})
     # LLVM MacPorts
     "/opt/local/libexec/llvm-${version}/include"
     # LLVM Homebrew
-    "/usr/local/Cellar/llvm/${version}/include"
+    "/usr/local/opt/llvm/include"
     # LLVM Homebrew/versions
     "/usr/local/lib/llvm-${version}/include"
     )
@@ -43,7 +43,7 @@ foreach (version ${LIBCLANG_KNOWN_LLVM_VERSIONS})
     # LLVM MacPorts
     "/opt/local/libexec/llvm-${version}/lib"
     # LLVM Homebrew
-    "/usr/local/Cellar/llvm/${version}/lib"
+    "/usr/local/opt/llvm/lib"
     # LLVM Homebrew/versions
     "/usr/local/lib/llvm-${version}/lib"
     )


### PR DESCRIPTION
A recent homebrew llvm update broke the building of the server (since the llvm version changed to 3.5.0_2). However, I noticed that homebrew provides version independent paths to the llvm includes and libraries, so switching to these should fix not only this update but remove the need to update FindLibClang for similar homebrew llvm updates in the future.
