### PR TITLE
Return toplevel ast from libclang to emacs-lisp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /local-data/
 /build/
 /bin/
+TAGS
+*~
+*.elc

--- a/irony-ast.el
+++ b/irony-ast.el
@@ -1,0 +1,298 @@
+;;; irony-ast.el --- generate AST with libclang -*- lexical-binding: t -*-
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'irony)
+(require 'cl-lib)
+(require 'cl)
+
+
+;;
+;; Internal variables and structures
+;;
+
+(cl-defstruct irony-ast
+  "Roughly corresponds to a value of a CXCursor.
+
+KIND is clang_getCursorKind
+
+START, END give the cursor range. They may be invalid if the file
+was edited since this cursor was generated.
+
+PARENT-KIND, PARENT-OFFSET specify parent cursor. Cursors are not
+necessarily nested within their parent (for example, comment
+cursors). The offset is parent's start relative to START. This
+way editing a buffer is less likely to invalidate old cursors."
+  ;; FIXME There is an assumption that there will not be two ast nodes
+  ;; of the same kind starting at the same location.
+  kind
+  start
+  end
+  parent
+  child
+  prev
+  next
+  hash
+  type
+  name
+  comment)
+
+
+;;
+;; Functions
+;;
+
+(defun irony-ast-toplevel ()
+  "Return the top-level AST node at point."
+  (let* (o parent)
+    (setq o (car (cl-remove-if-not
+                  (lambda (o) (eq (overlay-get o 'category) 'irony-ast))
+                  (overlays-at (point))))
+          parent (and o (irony-ast-parent (overlay-get o 'irony-ast))))
+    (while (and o (irony-ast-p parent))
+      (setq o (irony-ast--overlay-of-node parent)
+            parent (irony-ast-parent (overlay-get o 'irony-ast))))
+    (when o (overlay-get o 'irony-ast))))
+
+(defun irony-ast-current-nodes ()
+  "List of all AST nodes that overlap with point."
+  (mapcar (lambda (o) (overlay-get o 'irony-ast))
+          (cl-remove-if-not
+           (lambda (o) (eq (overlay-get o 'category) 'irony-ast))
+           (overlays-at (point)))))
+
+(defun irony-ast-current-node ()
+  "Return the inner-most AST node at point."
+  (car
+   (sort (irony-ast-current-nodes)
+         (lambda (n1 n2)
+           (> (irony-ast-node-depth n1) (irony-ast-node-depth n2))))))
+
+(defun irony-ast-node-depth (node)
+  (when (irony-ast-p node)
+    (let ((count 0))
+      (while (and (irony-ast-p node) (setq node (irony-ast-parent node)))
+        (cl-incf count))
+      count)))
+
+(defun irony-ast-async (callback &optional force)
+  "Ask for AST nodes to be regenerated if necessary, then call CALLBACK.
+
+If FORCE is non-nil, regenerate AST nodes in any case."
+  (if (unless force (irony-ast-current-node))
+      (funcall callback)
+    (irony-ast--send-request callback)))
+
+
+;;
+;; Implementation
+;;
+
+(defvar irony-ast--debug t)
+
+(defmacro irony-ast--debug (&rest message-args)
+  `(when irony-ast--debug (message ,@message-args)))
+
+;; Delete overlays on modification. irony-ast is the overlay category.
+(put 'irony-ast 'modification-hooks (list #'irony-ast--overlay-hook))
+(put 'irony-ast 'insert-in-front-hooks (list #'irony-ast--overlay-hook))
+(put 'irony-ast 'insert-behind-hooks (list #'irony-ast--overlay-hook))
+
+(defun irony-ast--overlay-hook (overlay &rest _)
+  (let ((node (overlay-get overlay 'irony-ast)))
+    (irony-ast--remove-overlays (irony-ast-start node) (irony-ast-end node))))
+
+(defun irony-ast--remove-overlays (begin end)
+  ;; We need to remove all overlays that either overlap with
+  ;; begin-end, or whose AST overlaps with begin-end.
+  (let ((min-begin begin) (max-end end))
+    (dolist (o (overlays-in begin end))
+      (when (and (eq (overlay-get o 'category) 'irony-ast) (overlay-start o))
+        ;; (irony-ast--debug "Delete overlay %s" o)
+        (delete-overlay o)
+        (let* ((node (overlay-get o 'irony-ast))
+               (parent (irony-ast-parent node)))
+          (cl-callf min min-begin (irony-ast-start node))
+          (cl-callf max max-end (irony-ast-end node))
+          (when (irony-ast-p parent)
+            (cl-callf min min-begin (irony-ast-start parent))
+            (cl-callf max max-end (irony-ast-end parent))))))
+    (when (< min-begin begin) (irony-ast--remove-overlays min-begin begin))
+    (when (> max-end end) (irony-ast--remove-overlays end max-end))))
+
+(defun irony-ast--overlay-of-node (node)
+  (let ((overlays
+         (cl-remove-if-not (lambda (o) (eq node (overlay-get o 'irony-ast)))
+                           (overlays-at (irony-ast-start node)))))
+    (when overlays
+      (cl-assert (eq (length overlays) 1))
+      (car overlays))))
+
+
+;;
+;; Interface with irony-server
+;;
+
+(defun irony-ast--context ()
+  (buffer-chars-modified-tick))
+
+(defun irony-ast--send-request (&optional callback)
+  "Send AST-generation request to irony-server."
+  (let (line column)
+    ;; FIXME Pass byte offset instead of line/col to avoid this
+    (save-excursion
+      ;; `position-bytes' to handle multibytes and 'multicolumns' (i.e
+      ;; tabulations) characters properly
+      (irony--without-narrowing
+        (setq line (line-number-at-pos)
+              column (1+ (- (position-bytes (point))
+                            (position-bytes (point-at-bol)))))))
+    ;; FIXME This should be ordinary let, but the rest of code needs
+    ;; to have lexical-binding then.
+    (lexical-let ((request-context (irony-ast--context))
+                  (user-callback callback))
+      (irony--send-file-request
+       "toplevelAST"
+       ;; FIXME There is some weirdness in how this function gets called
+       ;; The function called is the CAR of the callback
+       (list
+        (lambda (&rest args)
+          (when (equal request-context (irony-ast--context))
+            (apply #'irony-ast--request-handler (car args))
+            (when user-callback (funcall user-callback)))))
+       (number-to-string line)
+       (number-to-string column)))))
+
+(defun irony-ast--request-handler (&rest args)
+  ;; The first node is the top-level node.
+  (irony-ast--remove-overlays
+   (irony-ast-start (car args)) (irony-ast-end (car args)))
+  ;; Adjust all cursor references.
+  (dolist (node args)
+    (irony-ast--adjust-cursor-ref args (gv-ref (irony-ast-parent node)))
+    (irony-ast--adjust-cursor-ref args (gv-ref (irony-ast-child node)))
+    (irony-ast--adjust-cursor-ref args (gv-ref (irony-ast-prev node)))
+    (irony-ast--adjust-cursor-ref args (gv-ref (irony-ast-next node)))
+    (irony-ast--adjust-cursor-ref-list args (irony-ast-type node))
+    (cl-assert (not (eq node (irony-ast-parent node))))
+    (cl-assert (not (eq node (irony-ast-child node))))
+    (cl-assert (not (eq node (irony-ast-prev node))))
+    (cl-assert (not (eq node (irony-ast-next node)))))
+  (dolist (node args)
+    (unless (irony-ast-p node)
+      (irony-ast--debug "Bad node: %s" (prin1-to-string node))
+      (error "Unexpected output in irony-ast"))
+    (cl-callf copy-marker (irony-ast-start node))
+    (cl-callf copy-marker (irony-ast-end node))
+    (let ((o (make-overlay (irony-ast-start node) (irony-ast-end node))))
+      (overlay-put o 'category 'irony-ast)
+      (overlay-put o 'irony-ast node))))
+
+(defun irony-ast--adjust-cursor-ref (all-nodes cursor-ref)
+  (let ((ref (gv-deref cursor-ref)))
+    (when (eq (car ref) 'cursor-ref)
+      (setf (gv-deref cursor-ref)
+            (cl-find-if (lambda (node) (equal (irony-ast-hash node) (cadr ref)))
+                        all-nodes)))))
+
+(defun irony-ast--adjust-cursor-ref-list (all-nodes elems)
+  "Update all cursor-refs inside ELEMS"
+  (if (and (consp (car-safe elems)) (eq (caar elems) 'cursor-ref))
+      (irony-ast--adjust-cursor-ref all-nodes (gv-ref (car elems)))
+    (when (car-safe elems)
+      (irony-ast--adjust-cursor-ref-list all-nodes (car-safe elems))))
+  (when (cdr-safe elems)
+    (irony-ast--adjust-cursor-ref-list all-nodes (cdr-safe elems)))
+  nil)
+
+(when irony-ast--debug
+  (trace-function #'irony-ast--send-request)
+  (trace-function #'process-send-string)
+  (trace-function #'start-process)
+  (trace-function #'irony--send-file-request)
+  (trace-function #'irony--server-process-filter)
+  (trace-function #'irony--start-server-process)
+  (trace-function #'irony-ast--remove-overlays))
+
+
+;;
+;; Debug AST with highlighting overlays
+;;
+
+(defface irony-ast-face-0
+  '((t (:background "red")))
+  "irony-ast-face-0"
+  :group 'irony)
+(defface irony-ast-face-1
+  '((t (:background "gold")))
+  "irony-ast-face-1"
+  :group 'irony)
+(defface irony-ast-face-2
+  '((t (:background "yellow")))
+  "irony-ast-face-2"
+  :group 'irony)
+(defface irony-ast-face-3
+  '((t (:background "green")))
+  "irony-ast-face-3"
+  :group 'irony)
+(defface irony-ast-face-4
+  '((t (:background "light blue")))
+  "irony-ast-face-4"
+  :group 'irony)
+(defface irony-ast-face-5
+  '((t (:background "blue")))
+  "irony-ast-face-5"
+  :group 'irony)
+(defface irony-ast-face-6
+  '((t (:background "purple")))
+  "irony-ast-face-6"
+  :group 'irony)
+
+(defun irony-ast--level-face (level)
+  (pcase level
+    ((guard (< level 0)) 'irony-ast-face-0)
+    (0 'irony-ast-face-0)
+    (1 'irony-ast-face-1)
+    (2 'irony-ast-face-2)
+    (3 'irony-ast-face-3)
+    (4 'irony-ast-face-4)
+    (5 'irony-ast-face-5)
+    (6 'irony-ast-face-6)
+    (_ 'irony-ast-face-6)))
+
+(defun irony-ast--hl-node (current-depth node)
+  (let ((o (make-overlay (irony-ast-start node) (irony-ast-end node)))
+        (level (- current-depth (irony-ast-node-depth node))))
+    (overlay-put o 'category 'irony-ast-highlight-mode)
+    (overlay-put o 'face (irony-ast--level-face level))
+    (overlay-put o 'priority (- 60 level))))
+
+(defun irony-ast--hl ()
+  (with-demoted-errors "Error(irony-ast--hl): %S"
+    (remove-overlays nil nil 'category 'irony-ast-highlight-mode)
+    (let* ((current-node (irony-ast-current-node))
+           (current-depth (irony-ast-node-depth current-node)))
+      (dolist (node (irony-ast-current-nodes))
+        (irony-ast--hl-node current-depth node))
+      (let ((sibling current-node))
+        (while (and sibling (setq sibling (irony-ast-next sibling)))
+          (irony-ast--hl-node current-depth sibling)))
+      (let ((sibling current-node))
+        (while (and sibling (setq sibling (irony-ast-prev sibling)))
+          (irony-ast--hl-node current-depth sibling))))))
+
+(define-minor-mode irony-ast-debug-highlight-mode
+  "Highlight AST tree nodes."
+  :group 'irony
+  (cond
+   (irony-ast-debug-highlight-mode
+    (add-hook 'post-command-hook #'irony-ast--hl nil t))
+   (t
+    (remove-hook 'post-command-hook #'irony-ast--hl))))
+
+(provide 'irony-ast)
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+;;; irony-ast.el ends here

--- a/server/src/CMakeLists.txt
+++ b/server/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(irony-server
   support/NonCopyable.h
   support/TemporaryFile.cpp
   support/TemporaryFile.h
+  support/Sexp.cpp
 
   Command.cpp
   Commands.def

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -1,7 +1,7 @@
 /**
  * \file
  * \author Guillaume Papin <guillaume.papin@epitech.eu>
- * 
+ *
  * \brief Command parser definitions.
  *
  * This file is distributed under the GNU General Public License. See
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <cerrno>
 
 namespace {
 
@@ -152,6 +153,13 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     break;
 
   case Command::Complete:
+    positionalArgs.push_back(StringConverter(&command_.file));
+    positionalArgs.push_back(UnsignedIntConverter(&command_.line));
+    positionalArgs.push_back(UnsignedIntConverter(&command_.column));
+    handleUnsaved = true;
+    break;
+
+  case Command::ToplevelAST:
     positionalArgs.push_back(StringConverter(&command_.file));
     positionalArgs.push_back(UnsignedIntConverter(&command_.line));
     positionalArgs.push_back(UnsignedIntConverter(&command_.column));

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -16,6 +16,9 @@ X(Diagnostics, "diagnostics", "FILE - look for diagnostics in file")
 X(Complete,
   "complete",
   "FILE LINE COL - perform code completion at a given location")
+X(ToplevelAST,
+  "toplevelAST",
+  "FILE LINE COL - Return list of overlays for each AST node.")
 X(Help, "help", "show this message")
 X(Exit, "exit", "exit interactive mode, print nothing")
 X(SetDebug, "set-debug", "[on|off] - enable or disable verbose logging")
@@ -24,3 +27,7 @@ X(SetDebug, "set-debug", "[on|off] - enable or disable verbose logging")
 X(Unknown, "<unkown>",  "<unspecified>")
 
 #undef X
+
+// Local Variables:
+// flycheck-mode: nil
+// End:

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -60,11 +60,52 @@ public:
                 unsigned col,
                 const std::vector<std::string> &flags,
                 const std::vector<CXUnsavedFile> &unsavedFiles);
+
+  /// Return a list of AST nodes, starting from the inner-most
+  /// top-level node.
+  void toplevelAST(const std::string &file,
+                   unsigned line,
+                   unsigned col,
+                   const std::vector<std::string> &flags,
+                   const std::vector<CXUnsavedFile> &unsavedFiles);
+
   /// @}
+
+public:
+
+  /** Walk up the tree until the translation unit. We want the level
+      just below the TU. There are lexical and semantic parents, we
+      want the lexical parent, but sometimes it is invalid, in which
+      case we use the semantic parent instead. */
+  CXCursor getToplevelCursor(CXTranslationUnit, CXSourceLocation);
+
+  /** Recursive AST printer for irony-ast.el */
+  CXChildVisitResult astSexpPrinter(CXCursor, CXCursor);
 
 private:
   TUManager tuManager_;
   bool debug_;
 };
+
+/*
+  Utility functions.
+*/
+
+/** Return offset of cursor in its file.
+    Result type is long so that it can be subtracted without casting.
+*/
+long cursorOffset(CXCursor cursor);
+
+/**
+   Lexical or, if missing, semantic parent of a cursor.
+ */
+CXCursor getCursorParent(CXCursor cursor);
+
+/** Simple AST functions.
+ */
+CXCursor getCursorFirstChild(CXCursor cursor);
+CXCursor getCursorNext(CXCursor cursor, CXCursor parent);
+CXCursor getCursorPrev(CXCursor cursor, CXCursor parent);
+
 
 #endif // IRONY_MODE_SERVER_IRONY_H_

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -178,6 +178,10 @@ int main(int ac, const char *av[]) {
       irony.complete(c->file, c->line, c->column, c->flags, c->cxUnsavedFiles);
       break;
 
+    case Command::ToplevelAST:
+      irony.toplevelAST(c->file, c->line, c->column, c->flags, c->cxUnsavedFiles);
+      break;
+
     case Command::Exit:
       return 0;
 

--- a/server/src/support/Sexp.cpp
+++ b/server/src/support/Sexp.cpp
@@ -1,0 +1,179 @@
+#include "Sexp.h"
+#include "iomanip_quoted.h"
+
+#include "Sexp_CursorKind.cpp"
+#include "Sexp_TypeKind.cpp"
+
+#include <sstream>
+#include <cassert>
+#include <utility>
+
+namespace sexp {
+
+/** Sexp representation of a pointer to another cursor
+    (actually, of the form (cursor-ref HASH)). */
+detail::cursorRef_proxy cursorRef(CXCursor cursor) {
+  return detail::cursorRef(cursor);
+}
+
+/** Representation of type information for a cursor. */
+detail::type_proxy type(CXCursor cursor) {
+  return detail::type_proxy(cursor);
+}
+
+/** String representation of a cursor's brief comment. */
+detail::comment_proxy comment(CXCursor cursor) {
+  return detail::comment_proxy(cursor);
+}
+
+namespace detail {
+
+/** Libclang seems to return empty strings when there is nothing
+    meaningful to return, so empty strings are printed as nil. */
+std::ostream& operator<<(std::ostream& out, const sexp_proxy<CXString>& string) {
+  const char* data = clang_getCString(string.value);
+  if (!data) return out << "nil";
+  std::string s = std::string(data);
+  if (s == "") return out << "nil";
+  return out << support::quoted(s);
+}
+
+std::ostream& operator<<(std::ostream& out, const sexp_proxy<int>& integer) {
+  if (integer.value == -1) return out << "nil";
+  return out << integer.value;
+}
+
+std::ostream& operator<<(std::ostream& out, const sexp_proxy<bool>& boolean) {
+  return out << (boolean.value ? "t" : "nil");
+}
+
+std::ostream& operator<<(std::ostream& out, const sexp_proxy<CXType>& proxy) {
+  CXType type = proxy.value;
+  if (type.kind == CXType_Invalid) {
+    return out << "nil";
+  }
+
+  /* In principle, one could print everything libclang exposes about
+     the type here, but emacs-lisp doesn't use this yet, so there is
+     little reason. */
+
+  out << "(type";
+  if (type.kind == CXType_Unexposed) {
+    out << " nil";
+  } else {
+    out << " " << repr(type.kind);
+  }
+  out << " (spelling . " << repr(clang_getTypeSpelling(type)) << ")";
+  int num_args = clang_getNumArgTypes(type);
+  if (num_args > 0) {
+    out << " (args";
+    for (int i = 0; i < num_args; ++i) {
+      out << " " << repr(clang_getArgType(type, i));
+    }
+    out << ")";
+    // out << alistEntry("num-args", num_args);
+  }
+  // out << " (decl-cursor . " << sexp(clang_getTypeDeclaration(type)) << ")";
+  return out << ")";
+}
+
+std::ostream& operator<<(std::ostream& out, const type_proxy& type_proxy) {
+  CXCursor cursor = type_proxy.cursor;
+  CXType type = clang_getCursorType(cursor);
+
+  if (type.kind == CXType_Invalid) {
+    return out << "nil";
+  }
+
+  out << "(cursor-type"
+      << " " << repr(type);
+
+  out << alistEntry("typedef-underlying", repr(clang_getTypedefDeclUnderlyingType(cursor)));
+
+  int num_args = clang_Cursor_getNumArguments(cursor);
+  if (num_args > 0) {
+    out << " (args";
+    for (int i = 0; i < num_args; ++i) {
+      CXCursor arg_cursor = clang_Cursor_getArgument(cursor, i);
+      out << " " << cursorRef(arg_cursor);
+    }
+    out << ")";
+  }
+
+  CXCursor cursor_referenced = clang_getCursorReferenced(cursor);
+  if (!clang_isInvalid(clang_getCursorKind(cursor_referenced))) {
+    out << alistEntry("ref", cursorRef(cursor_referenced));
+  }
+
+  CXCursor cursor_def = clang_getCursorDefinition(cursor);
+  if (!clang_isInvalid(clang_getCursorKind(cursor_def))) {
+    out << alistEntry("def", cursorRef(cursor_def));
+  }
+
+  if (type.kind == CXType_Overload) {
+    CXCursor ref = cursor;
+    int num_overloaded = clang_getNumOverloadedDecls(ref);
+    // FIXME I'm not really sure what the rules are here
+    if (!num_overloaded) {
+      ref = cursor_referenced;
+      num_overloaded = clang_getNumOverloadedDecls(ref);
+    }
+    if (num_overloaded > 0) {
+      out << " (overloaded";
+      for (int i = 0; i < num_overloaded; ++i) {
+        CXCursor decl = clang_getOverloadedDecl(ref, i);
+        out << " " << repr(clang_getCursorType(decl));
+      }
+      out << ")";
+    }
+  }
+
+  // FIXME This is too recent (Dec 2014?)
+  // int num_template_args = clang_Cursor_getNumTemplateArguments(cursor);
+  // if (num_template_args > 0) {
+  //   out << " (template-args";
+  //   for (int i = 0; i < num_args; ++i) {
+  //     out << " ";
+  //     if (clang_Cursor_getTemplateArgumentKind(cursor, i)
+  //         == CXTemplateArgumentKind_Integral) {
+  //       out << clang_Cursor_getTemplateArgumentValue(cursor, i);
+  //     } else {
+  //       out << repr(clang_Cursor_getTemplateArgumentType(cursor, i));
+  //     }
+  //   }
+  // }
+
+  // out << alistEntry("num-template-args", clang_Cursor_getNumTemplateArguments(cursor));
+
+  out << ")";
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const cursorRef_proxy& cursorRef) {
+  if (clang_isInvalid(clang_getCursorKind(cursorRef.other_cursor))) {
+    out << "nil";
+  } else {
+    out << "(cursor-ref "
+        << "#x" << std::hex << clang_hashCursor(cursorRef.other_cursor) << std::dec
+        << ")";
+  }
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const comment_proxy& proxy) {
+  CXString comment = clang_Cursor_getBriefCommentText(proxy.cursor);
+  if (!clang_getCString(comment)) {
+    CXCursor cursor = clang_getCursorDefinition(proxy.cursor);
+    comment = clang_Cursor_getBriefCommentText(cursor);
+  }
+  if (!clang_getCString(comment)) {
+    CXCursor cursor = clang_getCursorReferenced(proxy.cursor);
+    comment = clang_Cursor_getBriefCommentText(cursor);
+  }
+  if (clang_getCString(comment)) out << repr(comment);
+  else out << "nil";
+  return out;
+}
+
+} // namespace detail
+} // namespace sexp

--- a/server/src/support/Sexp.h
+++ b/server/src/support/Sexp.h
@@ -1,0 +1,132 @@
+// -*- mode: c++ -*-
+#ifndef IRONYMODE_SERVER_SRC_SUPPORT_SEXP_H_
+#define IRONYMODE_SERVER_SRC_SUPPORT_SEXP_H_
+
+#include <clang-c/Index.h>
+#include <iostream>
+#include <string>
+#include <sstream>
+
+namespace sexp {
+
+namespace detail {
+
+template <typename T> struct sexp_proxy;
+struct cursorRef_proxy;
+struct type_proxy;
+struct comment_proxy;
+template <typename T> struct alistEntry_proxy;
+
+}
+
+/** Return printable representation of value as an emacs-lisp object.
+
+    There is a special implementation for type int that prints -1 as nil.
+
+    When printing cursors, the information about their parents is
+    unreliable (I think), so an AST walker should do this on its own.
+
+    When printing a representation of a CXString, the string will be
+    destroyed after printing (repr takes ownership).
+*/
+template <typename T>
+detail::sexp_proxy<T> repr(const T& value) { return {value}; }
+
+/** Sexp representation of a pointer to another cursor
+    (actually, of the form (cursor-ref HASH)). */
+detail::cursorRef_proxy cursorRef(CXCursor);
+
+/** Representation of type information for a cursor. */
+detail::type_proxy type(CXCursor);
+
+/** String representation of a cursor's brief comment. */
+detail::comment_proxy comment(CXCursor cursor);
+
+/** Print an alist entry of the form " (name . value)", omitting it if
+    value is nil, and printing parens nicely if value is a list.
+    Value is expected to be a single sexp.
+*/
+template <typename T>
+detail::alistEntry_proxy<T> alistEntry(const std::string& name, const T& value) { return {name, value}; }
+
+
+/* Implementation. */
+
+namespace detail {
+
+template <typename T>
+struct sexp_proxy {
+  sexp_proxy(const T& value) : value(value) { }
+  const T& value;
+};
+
+template <>
+struct sexp_proxy<CXString> {
+  sexp_proxy(const CXString& value) : value(value) { }
+  ~sexp_proxy() { clang_disposeString(value); }
+  const CXString& value;
+};
+
+std::ostream& operator<<(std::ostream&, const sexp_proxy<CXCursor>&);
+
+std::ostream& operator<<(std::ostream&, const sexp_proxy<CXString>&);
+std::ostream& operator<<(std::ostream&, const sexp_proxy<CXCursorKind>&);
+std::ostream& operator<<(std::ostream&, const sexp_proxy<CXTypeKind>&);
+std::ostream& operator<<(std::ostream&, const sexp_proxy<bool>&);
+std::ostream& operator<<(std::ostream&, const sexp_proxy<int>&);
+std::ostream& operator<<(std::ostream&, const sexp_proxy<CXType>&);
+
+struct cursorRef_proxy {
+  cursorRef_proxy(CXCursor other_cursor)
+    : other_cursor(other_cursor) { }
+  CXCursor other_cursor;
+};
+std::ostream& operator<<(std::ostream&, const cursorRef_proxy&);
+
+inline
+cursorRef_proxy cursorRef(CXCursor cursor) { return cursorRef_proxy(cursor); }
+
+/// Type information for CXCursors
+struct type_proxy {
+  type_proxy(const CXCursor& cursor) : cursor(cursor) { }
+  const CXCursor& cursor;
+};
+std::ostream& operator<<(std::ostream&, const type_proxy&);
+
+inline
+type_proxy type(CXCursor cursor) { return type_proxy(cursor); }
+
+/// Comment information for a given cursor.
+struct comment_proxy {
+  comment_proxy(const CXCursor& cursor) : cursor(cursor) { }
+  const CXCursor& cursor;
+};
+std::ostream& operator<<(std::ostream&, const comment_proxy&);
+
+/// See alistEntry.
+template <typename T>
+struct alistEntry_proxy {
+  alistEntry_proxy(std::string name, const T& value)
+    : name_(name), value_(value) { }
+  std::string name_;
+  const T& value_;
+};
+
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const alistEntry_proxy<T>& proxy) {
+  std::ostringstream sstream;
+  sstream << proxy.value_;
+  std::string s = sstream.str();
+  if (s == "nil") return out;
+  if (s[0] == '(' && s[s.size()-1] == ')') {
+    out << " (" << proxy.name_ << " " << s.substr(1);
+  } else {
+    out << " (" << proxy.name_ << " . " << s << ")";
+  }
+  return out;
+}
+
+} // namespace detail
+} // namespace sexp
+
+#endif // IRONYMODE_SERVER_SRC_SUPPORT_SEXP_H_

--- a/server/src/support/Sexp_CursorKind.cpp
+++ b/server/src/support/Sexp_CursorKind.cpp
@@ -1,0 +1,232 @@
+#include "Sexp.h"
+
+namespace sexp {
+namespace detail {
+
+std::string cursorKindName(CXCursorKind);
+
+std::ostream& operator<<(std::ostream& out, const sexp_proxy<CXCursorKind>& cursor_kind) {
+  return out << cursorKindName(cursor_kind.value);
+}
+
+/**
+
+   This is a rather large, automatically generated dump of
+   CXCursorKind definition, from the source in clang-c/Index.h.
+
+   It is a separate file so that it wouldn't pollute other files.
+
+   NOTE: There are CXCursor_(First|Last)* values; these are not real
+   and are commented out.
+
+   FIXME Some of these are undefined on my OSX, I don't know why.
+
+   FIXME Others are equal to each other, despite not being obviously
+   the same.
+*/
+
+std::string cursorKindName(CXCursorKind cursor_kind) {
+  switch (cursor_kind) {
+  case CXCursor_UnexposedDecl: return "UnexposedDecl";
+  case CXCursor_StructDecl: return "StructDecl";
+  case CXCursor_UnionDecl: return "UnionDecl";
+  case CXCursor_ClassDecl: return "ClassDecl";
+  case CXCursor_EnumDecl: return "EnumDecl";
+  case CXCursor_FieldDecl: return "FieldDecl";
+  case CXCursor_EnumConstantDecl: return "EnumConstantDecl";
+  case CXCursor_FunctionDecl: return "FunctionDecl";
+  case CXCursor_VarDecl: return "VarDecl";
+  case CXCursor_ParmDecl: return "ParmDecl";
+  case CXCursor_ObjCInterfaceDecl: return "ObjCInterfaceDecl";
+  case CXCursor_ObjCCategoryDecl: return "ObjCCategoryDecl";
+  case CXCursor_ObjCProtocolDecl: return "ObjCProtocolDecl";
+  case CXCursor_ObjCPropertyDecl: return "ObjCPropertyDecl";
+  case CXCursor_ObjCIvarDecl: return "ObjCIvarDecl";
+  case CXCursor_ObjCInstanceMethodDecl: return "ObjCInstanceMethodDecl";
+  case CXCursor_ObjCClassMethodDecl: return "ObjCClassMethodDecl";
+  case CXCursor_ObjCImplementationDecl: return "ObjCImplementationDecl";
+  case CXCursor_ObjCCategoryImplDecl: return "ObjCCategoryImplDecl";
+  case CXCursor_TypedefDecl: return "TypedefDecl";
+  case CXCursor_CXXMethod: return "CXXMethod";
+  case CXCursor_Namespace: return "Namespace";
+  case CXCursor_LinkageSpec: return "LinkageSpec";
+  case CXCursor_Constructor: return "Constructor";
+  case CXCursor_Destructor: return "Destructor";
+  case CXCursor_ConversionFunction: return "ConversionFunction";
+  case CXCursor_TemplateTypeParameter: return "TemplateTypeParameter";
+  case CXCursor_NonTypeTemplateParameter: return "NonTypeTemplateParameter";
+  case CXCursor_TemplateTemplateParameter: return "TemplateTemplateParameter";
+  case CXCursor_FunctionTemplate: return "FunctionTemplate";
+  case CXCursor_ClassTemplate: return "ClassTemplate";
+  case CXCursor_ClassTemplatePartialSpecialization: return "ClassTemplatePartialSpecialization";
+  case CXCursor_NamespaceAlias: return "NamespaceAlias";
+  case CXCursor_UsingDirective: return "UsingDirective";
+  case CXCursor_UsingDeclaration: return "UsingDeclaration";
+  case CXCursor_TypeAliasDecl: return "TypeAliasDecl";
+  case CXCursor_ObjCSynthesizeDecl: return "ObjCSynthesizeDecl";
+  case CXCursor_ObjCDynamicDecl: return "ObjCDynamicDecl";
+  case CXCursor_CXXAccessSpecifier: return "CXXAccessSpecifier";
+    // case CXCursor_FirstDecl: return "FirstDecl";
+    // case CXCursor_LastDecl: return "LastDecl";
+    // case CXCursor_FirstRef: return "FirstRef";
+  case CXCursor_ObjCSuperClassRef: return "ObjCSuperClassRef";
+  case CXCursor_ObjCProtocolRef: return "ObjCProtocolRef";
+  case CXCursor_ObjCClassRef: return "ObjCClassRef";
+  case CXCursor_TypeRef: return "TypeRef";
+  case CXCursor_CXXBaseSpecifier: return "CXXBaseSpecifier";
+  case CXCursor_TemplateRef: return "TemplateRef";
+  case CXCursor_NamespaceRef: return "NamespaceRef";
+  case CXCursor_MemberRef: return "MemberRef";
+  case CXCursor_LabelRef: return "LabelRef";
+  case CXCursor_OverloadedDeclRef: return "OverloadedDeclRef";
+  case CXCursor_VariableRef: return "VariableRef";
+    // case CXCursor_LastRef: return "LastRef";
+    // case CXCursor_FirstInvalid: return "FirstInvalid";
+  case CXCursor_InvalidFile: return "InvalidFile";
+  case CXCursor_NoDeclFound: return "NoDeclFound";
+  case CXCursor_NotImplemented: return "NotImplemented";
+  case CXCursor_InvalidCode: return "InvalidCode";
+    // case CXCursor_LastInvalid: return "LastInvalid";
+    // case CXCursor_FirstExpr: return "FirstExpr";
+  case CXCursor_UnexposedExpr: return "UnexposedExpr";
+  case CXCursor_DeclRefExpr: return "DeclRefExpr";
+  case CXCursor_MemberRefExpr: return "MemberRefExpr";
+  case CXCursor_CallExpr: return "CallExpr";
+  case CXCursor_ObjCMessageExpr: return "ObjCMessageExpr";
+  case CXCursor_BlockExpr: return "BlockExpr";
+  case CXCursor_IntegerLiteral: return "IntegerLiteral";
+  case CXCursor_FloatingLiteral: return "FloatingLiteral";
+  case CXCursor_ImaginaryLiteral: return "ImaginaryLiteral";
+  case CXCursor_StringLiteral: return "StringLiteral";
+  case CXCursor_CharacterLiteral: return "CharacterLiteral";
+  case CXCursor_ParenExpr: return "ParenExpr";
+  case CXCursor_UnaryOperator: return "UnaryOperator";
+  case CXCursor_ArraySubscriptExpr: return "ArraySubscriptExpr";
+  case CXCursor_BinaryOperator: return "BinaryOperator";
+  case CXCursor_CompoundAssignOperator: return "CompoundAssignOperator";
+  case CXCursor_ConditionalOperator: return "ConditionalOperator";
+  case CXCursor_CStyleCastExpr: return "CStyleCastExpr";
+  case CXCursor_CompoundLiteralExpr: return "CompoundLiteralExpr";
+  case CXCursor_InitListExpr: return "InitListExpr";
+  case CXCursor_AddrLabelExpr: return "AddrLabelExpr";
+  case CXCursor_StmtExpr: return "StmtExpr";
+  case CXCursor_GenericSelectionExpr: return "GenericSelectionExpr";
+  case CXCursor_GNUNullExpr: return "GNUNullExpr";
+  case CXCursor_CXXStaticCastExpr: return "CXXStaticCastExpr";
+  case CXCursor_CXXDynamicCastExpr: return "CXXDynamicCastExpr";
+  case CXCursor_CXXReinterpretCastExpr: return "CXXReinterpretCastExpr";
+  case CXCursor_CXXConstCastExpr: return "CXXConstCastExpr";
+  case CXCursor_CXXFunctionalCastExpr: return "CXXFunctionalCastExpr";
+  case CXCursor_CXXTypeidExpr: return "CXXTypeidExpr";
+  case CXCursor_CXXBoolLiteralExpr: return "CXXBoolLiteralExpr";
+  case CXCursor_CXXNullPtrLiteralExpr: return "CXXNullPtrLiteralExpr";
+  case CXCursor_CXXThisExpr: return "CXXThisExpr";
+  case CXCursor_CXXThrowExpr: return "CXXThrowExpr";
+  case CXCursor_CXXNewExpr: return "CXXNewExpr";
+  case CXCursor_CXXDeleteExpr: return "CXXDeleteExpr";
+  case CXCursor_UnaryExpr: return "UnaryExpr";
+  case CXCursor_ObjCStringLiteral: return "ObjCStringLiteral";
+  case CXCursor_ObjCEncodeExpr: return "ObjCEncodeExpr";
+  case CXCursor_ObjCSelectorExpr: return "ObjCSelectorExpr";
+  case CXCursor_ObjCProtocolExpr: return "ObjCProtocolExpr";
+  case CXCursor_ObjCBridgedCastExpr: return "ObjCBridgedCastExpr";
+  case CXCursor_PackExpansionExpr: return "PackExpansionExpr";
+  case CXCursor_SizeOfPackExpr: return "SizeOfPackExpr";
+  case CXCursor_LambdaExpr: return "LambdaExpr";
+  case CXCursor_ObjCBoolLiteralExpr: return "ObjCBoolLiteralExpr";
+  case CXCursor_ObjCSelfExpr: return "ObjCSelfExpr";
+    // case CXCursor_LastExpr: return "LastExpr";
+    // case CXCursor_FirstStmt: return "FirstStmt";
+  case CXCursor_UnexposedStmt: return "UnexposedStmt";
+  case CXCursor_LabelStmt: return "LabelStmt";
+  case CXCursor_CompoundStmt: return "CompoundStmt";
+  case CXCursor_CaseStmt: return "CaseStmt";
+  case CXCursor_DefaultStmt: return "DefaultStmt";
+  case CXCursor_IfStmt: return "IfStmt";
+  case CXCursor_SwitchStmt: return "SwitchStmt";
+  case CXCursor_WhileStmt: return "WhileStmt";
+  case CXCursor_DoStmt: return "DoStmt";
+  case CXCursor_ForStmt: return "ForStmt";
+  case CXCursor_GotoStmt: return "GotoStmt";
+  case CXCursor_IndirectGotoStmt: return "IndirectGotoStmt";
+  case CXCursor_ContinueStmt: return "ContinueStmt";
+  case CXCursor_BreakStmt: return "BreakStmt";
+  case CXCursor_ReturnStmt: return "ReturnStmt";
+  case CXCursor_GCCAsmStmt: return "GCCAsmStmt";
+    // case CXCursor_AsmStmt: return "AsmStmt";
+  case CXCursor_ObjCAtTryStmt: return "ObjCAtTryStmt";
+  case CXCursor_ObjCAtCatchStmt: return "ObjCAtCatchStmt";
+  case CXCursor_ObjCAtFinallyStmt: return "ObjCAtFinallyStmt";
+  case CXCursor_ObjCAtThrowStmt: return "ObjCAtThrowStmt";
+  case CXCursor_ObjCAtSynchronizedStmt: return "ObjCAtSynchronizedStmt";
+  case CXCursor_ObjCAutoreleasePoolStmt: return "ObjCAutoreleasePoolStmt";
+  case CXCursor_ObjCForCollectionStmt: return "ObjCForCollectionStmt";
+  case CXCursor_CXXCatchStmt: return "CXXCatchStmt";
+  case CXCursor_CXXTryStmt: return "CXXTryStmt";
+  case CXCursor_CXXForRangeStmt: return "CXXForRangeStmt";
+  case CXCursor_SEHTryStmt: return "SEHTryStmt";
+  case CXCursor_SEHExceptStmt: return "SEHExceptStmt";
+  case CXCursor_SEHFinallyStmt: return "SEHFinallyStmt";
+  case CXCursor_MSAsmStmt: return "MSAsmStmt";
+  case CXCursor_NullStmt: return "NullStmt";
+  case CXCursor_DeclStmt: return "DeclStmt";
+  case CXCursor_OMPParallelDirective: return "OMPParallelDirective";
+  case CXCursor_OMPSimdDirective: return "OMPSimdDirective";
+  case CXCursor_OMPForDirective: return "OMPForDirective";
+  case CXCursor_OMPSectionsDirective: return "OMPSectionsDirective";
+  case CXCursor_OMPSectionDirective: return "OMPSectionDirective";
+  case CXCursor_OMPSingleDirective: return "OMPSingleDirective";
+  case CXCursor_OMPParallelForDirective: return "OMPParallelForDirective";
+  case CXCursor_OMPParallelSectionsDirective: return "OMPParallelSectionsDirective";
+  case CXCursor_OMPTaskDirective: return "OMPTaskDirective";
+  case CXCursor_OMPMasterDirective: return "OMPMasterDirective";
+  case CXCursor_OMPCriticalDirective: return "OMPCriticalDirective";
+  case CXCursor_OMPTaskyieldDirective: return "OMPTaskyieldDirective";
+  case CXCursor_OMPBarrierDirective: return "OMPBarrierDirective";
+  case CXCursor_OMPTaskwaitDirective: return "OMPTaskwaitDirective";
+  case CXCursor_OMPFlushDirective: return "OMPFlushDirective";
+  case CXCursor_SEHLeaveStmt: return "SEHLeaveStmt";
+  case CXCursor_OMPOrderedDirective: return "OMPOrderedDirective";
+  case CXCursor_OMPAtomicDirective: return "OMPAtomicDirective";
+  case CXCursor_OMPForSimdDirective: return "OMPForSimdDirective";
+  case CXCursor_OMPParallelForSimdDirective: return "OMPParallelForSimdDirective";
+  case CXCursor_OMPTargetDirective: return "OMPTargetDirective";
+  case CXCursor_OMPTeamsDirective: return "OMPTeamsDirective";
+    // case CXCursor_LastStmt: return "LastStmt";
+  case CXCursor_TranslationUnit: return "TranslationUnit";
+    // case CXCursor_FirstAttr: return "FirstAttr";
+  case CXCursor_UnexposedAttr: return "UnexposedAttr";
+  case CXCursor_IBActionAttr: return "IBActionAttr";
+  case CXCursor_IBOutletAttr: return "IBOutletAttr";
+  case CXCursor_IBOutletCollectionAttr: return "IBOutletCollectionAttr";
+  case CXCursor_CXXFinalAttr: return "CXXFinalAttr";
+  case CXCursor_CXXOverrideAttr: return "CXXOverrideAttr";
+  case CXCursor_AnnotateAttr: return "AnnotateAttr";
+  case CXCursor_AsmLabelAttr: return "AsmLabelAttr";
+  case CXCursor_PackedAttr: return "PackedAttr";
+  case CXCursor_PureAttr: return "PureAttr";
+  case CXCursor_ConstAttr: return "ConstAttr";
+  case CXCursor_NoDuplicateAttr: return "NoDuplicateAttr";
+  case CXCursor_CUDAConstantAttr: return "CUDAConstantAttr";
+  case CXCursor_CUDADeviceAttr: return "CUDADeviceAttr";
+  case CXCursor_CUDAGlobalAttr: return "CUDAGlobalAttr";
+  case CXCursor_CUDAHostAttr: return "CUDAHostAttr";
+  case CXCursor_CUDASharedAttr: return "CUDASharedAttr";
+    // case CXCursor_LastAttr: return "LastAttr";
+  case CXCursor_PreprocessingDirective: return "PreprocessingDirective";
+  case CXCursor_MacroDefinition: return "MacroDefinition";
+  case CXCursor_MacroExpansion: return "MacroExpansion";
+    // NOTE duplicate
+    // case CXCursor_MacroInstantiation: return "MacroInstantiation";
+  case CXCursor_InclusionDirective: return "InclusionDirective";
+    // case CXCursor_FirstPreprocessing: return "FirstPreprocessing";
+    // case CXCursor_LastPreprocessing: return "LastPreprocessing";
+  case CXCursor_ModuleImportDecl: return "ModuleImportDecl";
+    // case CXCursor_FirstExtraDecl: return "FirstExtraDecl";
+    // case CXCursor_LastExtraDecl: return "LastExtraDecl";
+  default: return "UnknownCursorKind";
+  }
+}
+
+} // namespace detail
+} // namespace sexp

--- a/server/src/support/Sexp_TypeKind.cpp
+++ b/server/src/support/Sexp_TypeKind.cpp
@@ -1,0 +1,73 @@
+#include "Sexp.h"
+
+namespace sexp {
+namespace detail {
+
+/**
+   One big switch statement for pretty-printing CXTypeKind.
+ */
+
+std::string typeKindName(CXTypeKind type_kind) {
+  switch (type_kind) {
+  case CXType_Invalid: return "Invalid";
+  case CXType_Unexposed: return "Unexposed";
+  case CXType_Void: return "Void";
+  case CXType_Bool: return "Bool";
+  case CXType_Char_U: return "U";
+  case CXType_UChar: return "UChar";
+  case CXType_Char16: return "Char16";
+  case CXType_Char32: return "Char32";
+  case CXType_UShort: return "UShort";
+  case CXType_UInt: return "UInt";
+  case CXType_ULong: return "ULong";
+  case CXType_ULongLong: return "ULongLong";
+  case CXType_UInt128: return "UInt128";
+  case CXType_Char_S: return "S";
+  case CXType_SChar: return "SChar";
+  case CXType_WChar: return "WChar";
+  case CXType_Short: return "Short";
+  case CXType_Int: return "Int";
+  case CXType_Long: return "Long";
+  case CXType_LongLong: return "LongLong";
+  case CXType_Int128: return "Int128";
+  case CXType_Float: return "Float";
+  case CXType_Double: return "Double";
+  case CXType_LongDouble: return "LongDouble";
+  case CXType_NullPtr: return "NullPtr";
+  case CXType_Overload: return "Overload";
+  case CXType_Dependent: return "Dependent";
+  case CXType_ObjCId: return "ObjCId";
+  case CXType_ObjCClass: return "ObjCClass";
+  case CXType_ObjCSel: return "ObjCSel";
+  // case CXType_FirstBuiltin: return "FirstBuiltin";
+  // case CXType_LastBuiltin  = case CXType_ObjCSel,;
+  case CXType_Complex: return "Complex";
+  case CXType_Pointer: return "Pointer";
+  case CXType_BlockPointer: return "BlockPointer";
+  case CXType_LValueReference: return "LValueReference";
+  case CXType_RValueReference: return "RValueReference";
+  case CXType_Record: return "Record";
+  case CXType_Enum: return "Enum";
+  case CXType_Typedef: return "Typedef";
+  case CXType_ObjCInterface: return "ObjCInterface";
+  case CXType_ObjCObjectPointer: return "ObjCObjectPointer";
+  case CXType_FunctionNoProto: return "FunctionNoProto";
+  case CXType_FunctionProto: return "FunctionProto";
+  case CXType_ConstantArray: return "ConstantArray";
+  case CXType_Vector: return "Vector";
+  case CXType_IncompleteArray: return "IncompleteArray";
+  case CXType_VariableArray: return "VariableArray";
+  case CXType_DependentSizedArray: return "DependentSizedArray";
+  case CXType_MemberPointer: return "MemberPointer";
+  default: return "UnknownCXTypeKind";
+  }
+}
+
+std::ostream& operator<<(std::ostream& out,
+                       const sexp_proxy<CXTypeKind>& type_kind)
+{
+  return out << typeKindName(type_kind.value);
+}
+
+} // namespace detail
+} // namespace sexp

--- a/server/src/support/iomanip_quoted.h
+++ b/server/src/support/iomanip_quoted.h
@@ -17,12 +17,13 @@ namespace support {
 namespace detail {
 
 struct quoted_string_proxy {
-  quoted_string_proxy(std::string &s) : s(s) {
+  quoted_string_proxy(const std::string &s) : s(s) {
   }
 
   const std::string &s;
 };
 
+inline
 std::ostream &operator<<(std::ostream &os, const quoted_string_proxy &q) {
   const std::string &s = q.s;
 
@@ -43,7 +44,8 @@ std::ostream &operator<<(std::ostream &os, const quoted_string_proxy &q) {
 
 } // namespace detail
 
-detail::quoted_string_proxy quoted(std::string &s) {
+inline
+detail::quoted_string_proxy quoted(const std::string &s) {
   return detail::quoted_string_proxy(s);
 }
 


### PR DESCRIPTION
I was trying to get irony-eldoc to use libclang's accurate type information, and for that I need to return cursors' type information to emacs-lisp. Since irony-eldoc can be run quite often, I also need to return cursors' information in bulk.

This makes a new server command that returns a list of cursors, with type information, and links to each other within the toplevel cursor surrounding current point. The idea is that emacs-lisp code can then traverse the AST that libclang produces, and that returning more information would easily result in the cursor information becoming stale.

The main entry point in emacs-lisp code is the `(irony-ast-async callback)`, which puts libclang's AST in some overlays on top of the buffer text, and then calls the callback. I included a small debugging mode that highlights current node and siblings in different colours depending on node depth (`irony-ast-debug-highlight-mode`).

The implementation is fairly straightforward, just basic cursor manipulation and walking over libclang's AST printing sexp representations of useful information, and I left some debugging messages in emacs-lisp code to help reading. These should be turned off later.

I tried to keep to your C++ style, but I'm not sure how close it is.

Please let me know what you think about this. As far as I know, this is the most precise C++ AST one can have directly in emacs, and there would be other uses for it too besides eldoc support.

- Kirill