### PR TITLE
irony.el: check irony--server-process at irony-server-kill

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -578,7 +578,7 @@ list (and undo information is not kept).")
 (defun irony-server-kill ()
   "Kill the running irony-server process, if any."
   (interactive)
-  (when (process-live-p irony--server-process)
+  (when (and irony--server-process (process-live-p irony--server-process))
     (kill-process irony--server-process)
     (setq irony--server-process nil)))
 


### PR DESCRIPTION
Check that irony--server-process is non-nil before calling process-live-p.
Fixes error "Buffer ... has no process" when installing irony on a new
machine.

See https://github.com/Sarcasm/irony-mode/issues/145
