### PR TITLE
Improve path search in Windows

### DIFF
--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -58,7 +58,7 @@ foreach (version ${LIBCLANG_KNOWN_LLVM_VERSIONS})
 endforeach()
 
 find_path(LIBCLANG_INCLUDE_DIR clang-c/Index.h
-  PATHS ${libclang_llvm_header_search_paths}
+  PATHS ${libclang_llvm_header_search_paths} ENV PATH
   PATH_SUFFIXES LLVM/include #Windows package from http://llvm.org/releases/
   DOC "The path to the directory that contains clang-c/Index.h")
 
@@ -71,7 +71,7 @@ if (MSVC)
 endif()
 
 find_library(LIBCLANG_LIBRARY NAMES libclang.imp libclang clang
-  PATHS ${libclang_llvm_lib_search_paths}
+  PATHS ${libclang_llvm_lib_search_paths} ENV PATH
   PATH_SUFFIXES LLVM/lib #Windows package from http://llvm.org/releases/
   DOC "The file that corresponds to the libclang library.")
 


### PR DESCRIPTION
I installed LLVM to a slightly nonstandard folder (E:/Program Files/ on
my external hard drive.)  Since the folder was already in my environment
path making this change allows irony-server to compile without any
system path modifications. Build environment is CMake 3.2.1, MSVC 2013, and Windows 8. 