### PR TITLE
Filter unavailable and inaccessible completions

### DIFF
--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -215,11 +215,18 @@ void Irony::complete(const std::string &file,
 
     for (unsigned i = 0; i < completions->NumResults; ++i) {
       CXCompletionResult candidate = completions->Results[i];
+      CXAvailabilityKind availability =
+          clang_getCompletionAvailability(candidate.CompletionString);
 
       unsigned priority =
           clang_getCompletionPriority(candidate.CompletionString);
       unsigned annotationStart = 0;
       bool typedTextSet = false;
+
+      if (availability == CXAvailability_NotAccessible ||
+          availability == CXAvailability_NotAvailable) {
+        continue;
+      }
 
       typedtext.clear();
       brief.clear();


### PR DESCRIPTION
Based on the comments in https://github.com/Sarcasm/irony-mode/issues/200 I wanted to give this is shot. It was a lot more straightforward than I anticipated.

This skips completions that are unavailable or inaccessible and would result in error if used.

I tested this out with some classes containing private members and verified that those members no longer showed up in the company-mode completion list.