### PR TITLE
Can now use relative paths to project root and compile commands.

### DIFF
--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -64,7 +64,8 @@ directories to project directory."
        (list proot (read-file-name "Compile commands:" proot nil t
                                    "compile_commands.json")))))
   (add-to-list 'irony-cdb-json--project-alist
-               (cons project-root compile-commands-path))
+               (cons (expand-file-name project-root)
+                     (expand-file-name compile-commands-path)))
   (irony-cdb-json--save-project-alist))
 
 (defun irony-cdb-json--get-compile-options ()


### PR DESCRIPTION
Previously, relative paths to project root and compile commands caused problems. If for instance project root was specified using ~, irony-cdb-json--find-best-prefix-path would fail to match.