### PR TITLE
Server guessing

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -27,7 +27,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 	
 if(IRONY_COMPILER_IS_GCC_COMPATIBLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 elseif(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c- /D_HAS_EXCEPTIONS=0")
   # irony-server uses some code that breaks when iterator debugging is enabled

--- a/server/src/CMakeLists.txt
+++ b/server/src/CMakeLists.txt
@@ -2,6 +2,9 @@ include(CheckLibClangBuiltinHeadersDir)
 
 find_package(LibClang REQUIRED)
 
+find_library(BOOST_SYSTEM boost_system)
+find_library(BOOST_FILESYSTEM boost_filesystem)
+
 include_directories(${LIBCLANG_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -65,6 +68,6 @@ set_source_files_properties(main.cpp
   PROPERTIES
   COMPILE_DEFINITIONS IRONY_PACKAGE_VERSION=\"${IRONY_PACKAGE_VERSION}\")
 
-target_link_libraries(irony-server ${LIBCLANG_LIBRARIES})
+target_link_libraries(irony-server ${LIBCLANG_LIBRARIES} ${BOOST_FILESYSTEM} ${BOOST_SYSTEM})
 
 install(TARGETS irony-server DESTINATION bin)

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -172,6 +172,10 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     // no-arguments commands
     break;
 
+  case Command::GetAllFiles:
+    positionalArgs.push_back(StringConverter(&command_.dir));
+    break;
+
   case Command::GetCompileOptions:
     positionalArgs.push_back(StringConverter(&command_.dir));
     positionalArgs.push_back(StringConverter(&command_.file));

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -17,6 +17,8 @@ X(Diagnostics, "diagnostics", "print the diagnostics of the last parse")
 X(Exit, "exit", "exit interactive mode, print nothing")
 X(GetCompileOptions, "get-compile-options", "BUILD_DIR FILE - "
   "get compile options for FILE from JSON database in PROJECT_ROOT")
+X(GetAllFiles, "get-all-files", "BUILD_DIR"
+  "get the name of all files in the compilation database")
 X(Help, "help", "show this message")
 X(Parse, "parse", "FILE - parse the given file")
 X(SetDebug, "set-debug", "[on|off] - enable or disable verbose logging")

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -337,17 +337,57 @@ void Irony::complete(const std::string &file,
 
 }
 
-void Irony::getAllFiles(const std::string &buildDir) {
 #if HAS_COMPILATION_DATABASE
-  CXCompilationDatabase_Error error;
-  CXCompilationDatabase db =
-    clang_CompilationDatabase_fromDirectory(buildDir.c_str(), &error);
 
-  // TODO: Compute ad print all filenames
+class CompilationDatabase {
+public:
+  explicit CompilationDatabase(std::string buildDir) : buildDir(buildDir) {
+    db = clang_CompilationDatabase_fromDirectory(buildDir.c_str(), &error);
+
+    switch (error) {
+    case CXCompilationDatabase_CanNotLoadDatabase:
+      std::clog << "I: could not load compilation database in '" << buildDir
+                << "'\n";
+      break;
+    case CXCompilationDatabase_NoError:
+      constructFileNames();
+      break;
+    }
+  }
+
+  CompilationDatabase &operator=(const CompilationDatabase&) = delete;
+  CompilationDatabase(const CompilationDatabase&) = delete;
+  CompilationDatabase &operator=(CompilationDatabase&&) = delete;
+  CompilationDatabase(CompilationDatabase&&) = delete;
+
+  ~CompilationDatabase() {
+    if (error == CXCompilationDatabase_NoError)
+      clang_CompilationDatabase_dispose(db);
+  }
+
+  bool isValid() const { return error == CXCompilationDatabase_NoError; }
+  const std::string &getBuildDir() const { return buildDir; }
+  const std::vector<std::string> &getAllFiles() const { return files; }
+  std::vector<std::vector<std::string>>
+  getCompileCommands(const std::string &file);
+  std::vector<std::string> guessCompileCommand(const std::string &file);
+
+private:
+  void constructFileNames();
+
+  std::string buildDir;
+  CXCompilationDatabase db;
+  CXCompilationDatabase_Error error;
+  std::vector<std::string> files;
+};
+
+void CompilationDatabase::constructFileNames() {
+  assert(error == CXCompilationDatabase_NoError &&
+         "Should only be called if database was loaded!");
+
   CXCompileCommands cmds = clang_CompilationDatabase_getAllCompileCommands(db);
   unsigned ncmds = clang_CompileCommands_getSize(cmds);
 
-  std::cout << "(\n";
   for (unsigned i = 0; i < ncmds; ++i) {
     CXCompileCommand cmd = clang_CompileCommands_getCommand(cmds, i);
 
@@ -378,21 +418,95 @@ void Irony::getAllFiles(const std::string &buildDir) {
       break;
     }
 
-    // std::cout << "File: " << file << "\tWorking dir: " << workingDir << "\n";
-
     path filePath(file);
 
-    // Add directory
+    // Make absolute
     if (filePath.is_relative())
       filePath = path(workingDir) /= filePath;
 
-    std::cout << filePath.make_preferred().native() << "\n";
+    files.push_back(filePath.make_preferred().native());
+  }
+
+  clang_CompileCommands_dispose(cmds);
+}
+
+std::vector<std::vector<std::string>>
+CompilationDatabase::getCompileCommands(const std::string &file) {
+  std::vector<std::vector<std::string>> compileCommands;
+
+  assert(isValid() && "Should have loaded the database without error!");
+
+  CXCompileCommands cxCompileCommands =
+      clang_CompilationDatabase_getCompileCommands(db, file.c_str());
+  unsigned numCompileCommands =
+      clang_CompileCommands_getSize(cxCompileCommands);
+
+  compileCommands.resize(numCompileCommands);
+
+  for (unsigned i = 0; i < numCompileCommands; ++i) {
+    std::vector<std::string> &compileCommand = compileCommands[i];
+
+    CXCompileCommand cxCompileCommand =
+        clang_CompileCommands_getCommand(cxCompileCommands, i);
+    unsigned numArgs = clang_CompileCommand_getNumArgs(cxCompileCommand);
+
+    CXString directory = clang_CompileCommand_getDirectory(cxCompileCommand);
+    compileCommand.reserve(numArgs + 1);
+    compileCommand.push_back(clang_getCString(directory));
+    clang_disposeString(directory);
+
+    for (unsigned j = 0; j < numArgs; ++j) {
+      CXString arg = clang_CompileCommand_getArg(cxCompileCommand, j);
+      compileCommand.push_back(clang_getCString(arg));
+      clang_disposeString(arg);
+    }
+  }
+
+  clang_CompileCommands_dispose(cxCompileCommands);
+  return compileCommands;
+}
+
+std::vector<std::string>
+CompilationDatabase::guessCompileCommand(const std::string &file) {
+  std::vector<std::string> compileCmd;
+  // TODO: Implement
+  return compileCmd;
+}
+
+bool Irony::loadCompilationDatabase(const std::string &buildDir) {
+  if (db && db->getBuildDir() == buildDir)
+    return true;
+
+  db.reset(new CompilationDatabase(buildDir));
+
+  if (!db->isValid()) {
+    db.reset();
+    return false;
+  }
+  return true;
+}
+
+#endif // HAS_COMPILATION_DATABASE
+
+// The destructor of Irony needs to see the complete type CompilationDatabase
+// because of the unique_ptr.
+Irony::~Irony() = default;
+
+void Irony::getAllFiles(const std::string &buildDir) {
+#if HAS_COMPILATION_DATABASE
+  if (!loadCompilationDatabase(buildDir)) {
+    std::cout << "nil\n";
+    return;
+  }
+
+  std::vector<std::string> files = db->getAllFiles();
+
+  std::cout << "(\n";
+  for (const std::string &file : files) {
+    std::cout << support::quoted(file) << "\n";
   }
   std::cout << ")\n";
 
-  clang_CompileCommands_dispose(cmds);
-
-  clang_CompilationDatabase_dispose(db);
 #else // !HAS_COMPILATION_DATABASE
 
   std::cout << "nil\n";
@@ -401,7 +515,7 @@ void Irony::getAllFiles(const std::string &buildDir) {
 }
 
 void Irony::getCompileOptions(const std::string &buildDir,
-                              const std::string &file) const {
+                              const std::string &file) {
 #if !(HAS_COMPILATION_DATABASE)
 
   (void)buildDir;
@@ -411,55 +525,39 @@ void Irony::getCompileOptions(const std::string &buildDir,
   return;
 
 #else
-  CXCompilationDatabase_Error error;
-  CXCompilationDatabase db =
-      clang_CompilationDatabase_fromDirectory(buildDir.c_str(), &error);
 
-  switch (error) {
-  case CXCompilationDatabase_CanNotLoadDatabase:
-    std::clog << "I: could not load compilation database in '" << buildDir
-              << "'\n";
+  if (!loadCompilationDatabase(buildDir)) {
     std::cout << "nil\n";
     return;
-
-  case CXCompilationDatabase_NoError:
-    break;
   }
 
-  CXCompileCommands compileCommands =
-      clang_CompilationDatabase_getCompileCommands(db, file.c_str());
+  std::vector<std::vector<std::string>> compileCommands =
+      db->getCompileCommands(file);
 
   std::cout << "(\n";
+  for (const std::vector<std::string>& compileCommand : compileCommands) {
+    assert(!compileCommand.empty() &&
+           "Should at least contain the working directory!");
 
-  for (unsigned i = 0, numCompileCommands =
-                           clang_CompileCommands_getSize(compileCommands);
-       i < numCompileCommands; ++i) {
-    CXCompileCommand compileCommand =
-        clang_CompileCommands_getCommand(compileCommands, i);
+    std::cout << "( ";
 
-    std::cout << "("
-              << "(";
-    for (unsigned j = 0,
-                  numArgs = clang_CompileCommand_getNumArgs(compileCommand);
-         j < numArgs; ++j) {
-      CXString arg = clang_CompileCommand_getArg(compileCommand, j);
-      std::cout << support::quoted(clang_getCString(arg)) << " ";
-      clang_disposeString(arg);
+    std::cout << "(";
+    for (std::vector<std::string>::const_iterator
+             i = std::next(compileCommand.begin()),
+             e = compileCommand.end();
+         i != e; ++i) {
+      const std::string& compileArg = *i;
+      std::cout << support::quoted(compileArg) << " ";
     }
+    std::cout << ")";
 
-    std::cout << ")"
-              << " . ";
+    std::cout << " . ";
 
-    CXString directory = clang_CompileCommand_getDirectory(compileCommand);
-    std::cout << support::quoted(clang_getCString(directory));
-    clang_disposeString(directory);
+    std::cout << support::quoted(compileCommand[0]);
+    std::cout << " )\n";
 
-    std::cout << ")\n";
   }
-
   std::cout << ")\n";
 
-  clang_CompileCommands_dispose(compileCommands);
-  clang_CompilationDatabase_dispose(db);
 #endif
 }

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -20,10 +20,16 @@
 
 #include <string>
 #include <vector>
+#include <memory>
+
+#if HAS_COMPILATION_DATABASE
+class CompilationDatabase;
+#endif
 
 class Irony {
 public:
   Irony();
+  ~Irony();
 
   bool isDebugEnabled() const {
     return debug_;
@@ -96,14 +102,17 @@ public:
   /// \endcode
   ///
   void getCompileOptions(const std::string &buildDir,
-                         const std::string &file) const;
+                         const std::string &file);
 
   /// \}
 
 private:
+  bool loadCompilationDatabase(const std::string &buildDir);
+
   TUManager tuManager_;
   CXTranslationUnit activeTu_;
   bool debug_;
+  std::unique_ptr<CompilationDatabase> db;
 };
 
 #endif // IRONY_MODE_SERVER_IRONY_H_

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -78,6 +78,9 @@ public:
                 const std::vector<std::string> &flags,
                 const std::vector<CXUnsavedFile> &unsavedFiles);
 
+  // TODO: Documentation
+  void getAllFiles(const std::string &buildDir);
+
   /// \brief Get compile options from JSON database.
   ///
   /// \param buildDir Directory containing compile_commands.json

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -215,6 +215,10 @@ int main(int ac, const char *av[]) {
       irony.setDebug(c->opt);
       break;
 
+    case Command::GetAllFiles:
+      irony.getAllFiles(c->dir);
+      break;
+
     case Command::GetCompileOptions:
       irony.getCompileOptions(c->dir, c->file);
       break;


### PR DESCRIPTION
This is just to give you an idea of in what direction I'm working, since I'd like to hear what you think before I put in more time. This is basically the caching of the compilation database, but it's a very crude solution so far. It also contains the reconstruction of the file names I was talking about.

Things I will change/continue to work on:
* TODO Parse the whole database and save using C++ std::string instead?
* TODO Reparse database if out of date
* TODO Add command for forcing a reparse?
* TODO Close paths guessing algorithm
* TODO Menu for choosing the compile command
* TODO Implement file path operations (get rid of Boost) 
* TODO Testing of the above
