### PR TITLE
Useful additions to irony-cdb-json

### DIFF
--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -66,7 +66,10 @@ directories to project directory."
   (add-to-list 'irony-cdb-json--project-alist
                (cons (expand-file-name project-root)
                      (expand-file-name compile-commands-path)))
-  (irony-cdb-json--save-project-alist))
+  (irony-cdb-json--save-project-alist)
+
+  ; and tell irony to load it now
+  (irony-cdb-autosetup-compile-options))
 
 (defun irony-cdb-json--get-compile-options ()
   (irony--awhen (irony-cdb-json--locate-db)

--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -115,9 +115,11 @@ directories to project directory."
 
 (defun irony-cdb-json--locate-db ()
   (irony-cdb-json--ensure-project-alist-loaded)
-  (irony--aif (locate-dominating-file (irony-cdb-json--target-path)
-                                      "compile_commands.json")
-      (expand-file-name "compile_commands.json" it)
+  (irony--aif (irony-cdb--locate-dominating-file-with-dirs
+               (irony-cdb-json--target-path)
+               "compile_commands.json"
+               irony-cdb-search-directory-list)
+      (expand-file-name it)
     ;; if not in a parent directory, look in the project alist
     (irony--awhen (irony-cdb-json--find-best-prefix-path
                    (irony-cdb-json--target-path)

--- a/irony-cdb.el
+++ b/irony-cdb.el
@@ -63,6 +63,20 @@ for files that it cannot handle."
   :type '(repeat function)
   :group 'irony-cdb)
 
+(defcustom irony-cdb-search-directory-list '("." "build")
+  "List of relative subdirectory paths to be searched for cdb files
+
+Irony looks for cdb files in any of the supported format by checking
+each directory from the currently loaded file and recursively through
+parent directories until it hits the root directory or a cdb is
+found. At each level of the search irony looks at the subdirectories
+listed in `'irony-cdb-search-directory-list` for the files. Customize this
+list if your cdb is held in a custom directory within you project,
+such as a custom named build directory.
+"
+  :type '(repeat string)
+  :group 'irony-cdb)
+
 
 ;;
 ;; Internal variables

--- a/irony-cdb.el
+++ b/irony-cdb.el
@@ -128,6 +128,57 @@ such as a custom named build directory.
 ;; Functions
 ;;
 
+(defun irony-cdb--choose-closest-path (file paths)
+  "Find the \"best\" path in PATHS matching FILE
+
+If any paths in PATHS is belongs to the same directory
+or a subdirectory of file, we disregard other candidates.
+
+For remaining candidates, \"nearest\" is measured as abs. difference
+in path depth.
+- We prefer deeper paths at level +N to those at level -N.
+- If multiple paths are equally good, we return the last one.
+
+Returns nil if paths isn't a list of at least one element.
+"
+  (when (listp paths)
+    (let ((paths (or
+                  ;; if we find a cdb in cwd or below, don't consider other candidates
+                  (cl-remove-if-not (lambda (x) (string-prefix-p (file-name-directory file) x)) paths)
+                  paths)))
+      (cl-loop for path in paths
+         with best-depth-delta = 999999 ; start at +inf
+         with best-path = nil ; we keep the best so far here
+         ;; all candidates have their depth compared to that of target file
+         with file-depth = (length (split-string file "/")) ;
+         for candidate-depth = (length (split-string path "/"))
+         ;; Our metric. We use signum as a tie-breaker to choose deeper candidates
+         for depth-delta = (+ (abs (- file-depth candidate-depth))
+                              (* 0.1 (- file-depth candidate-depth)))
+         do (when (< depth-delta best-depth-delta)
+              (progn
+                (setq best-depth-delta depth-delta)
+                (setq best-path path)))
+         finally return best-path))))
+
+(defun irony-cdb--locate-dominating-file-with-dirs (file
+                                                    name
+                                                    subdirectories)
+  "Convenience wrapper around `locate-dominating-file'
+
+Looks up the directory hierarchy from FILE for to locate any directory
+in `subdirectories` which contains NAME. If multiple files are found,
+chooses the one located at the nearest directory level. if multiple
+files are found at the same level, picks the first one encountered.
+returns the full path to file if found, or nil otherwise."
+  (let ((candidates
+         (cl-loop for subdir in subdirectories
+            for relpath = (concat (file-name-as-directory subdir) name)
+            for match-maybe = (locate-dominating-file file relpath)
+            when match-maybe collect (expand-file-name (concat match-maybe relpath)))))
+    (irony-cdb--choose-closest-path file candidates)))
+
+
 (defun irony-cdb--update-compile-options (compile-options
                                           &optional working-directory)
   (setq irony--compile-options compile-options

--- a/server/test/elisp/irony-cdb-json.el
+++ b/server/test/elisp/irony-cdb-json.el
@@ -27,3 +27,33 @@
    (equal "/home/user/project/build"
           (nth 2 (irony-cdb-json--transform-compile-command
                   irony-cdb/compile-command)))))
+
+(ert-deftest cdb/choose-closest-path/chooses-closest ()
+  (should
+   (equal "/tmp/a/cdb"
+          (irony-cdb--choose-closest-path "/tmp/a/1"
+                                          '("/tmp/a/cdb" "/tmp/cdb")))))
+
+(ert-deftest cdb/choose-closest-path/chooses-closest2 ()
+  (should
+   (equal "/tmp/a/cdb"
+          (irony-cdb--choose-closest-path "/tmp/a/1"
+                                          '("/tmp/cdb" "/tmp/a/cdb")))))
+
+(ert-deftest cdb/choose-closest-path/prefers-deeper ()
+  (should
+   (equal "/tmp/a/build/cdb"
+          (irony-cdb--choose-closest-path "/tmp/a/1"
+                                          '("/tmp/a/build/cdb" "/tmp/cdb")))))
+
+(ert-deftest cdb/choose-closest-path/prefers-deeper2 ()
+  (should
+   (equal "/tmp/a/build/cdb"
+          (irony-cdb--choose-closest-path "/tmp/a/1"
+                                          '("/tmp/cdb" "/tmp/a/build/cdb")))))
+
+(ert-deftest cdb/choose-closest-path/will-survive-garbage ()
+  (should
+   (equal nil
+          (irony-cdb--choose-closest-path "/tmp/a/1"
+                                          'ordures))))


### PR DESCRIPTION
closes #234, #236 maybe some issues linked there as well. 

First, now looks recursively for parents for both ".json" and "build/.json". (#234)

Second, #236. One confusing bit is that calling `irony-cdb-json-add-compile-commands-path`
doesn't actually finish by loading the database you added. That might be "Cleaner", but
its inconvenient and under-documented. Commit 2 fixes that.

Third, still #236, I was led astray by `add-compile-commands-path` asking for both
project root and cdb path and ended up choosing the build directory, then the file within it.
I may not have been paying enough attention, but the issues suggest I may not be
the only one. So, commit 3 adds an alternative which takes only a cdb path,
loads it, and uses the source file paths in it to find the project root as the deepest
dir parenting everything in the cdb.
I would have just replaced `add-compile-commands-path` entirely, but that's public
and the new function takes one argument less. If you like the idea and don't mind
breaking the API, go for it.

Please review/test, I only wrote it, I haven't actually tested it (much) :)

If you merge 1m my problem is basically solved. 2 I think is reasonable. 3 was just
frustration.