### PR TITLE
ignore errors in server response processing

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -588,7 +588,8 @@ list (and undo information is not kept).")
 (defun irony--process-server-response (process response)
   (let ((sexp (read response))
         (callback (irony--server-process-pop-callback process)))
-    (apply (car callback) sexp (cdr callback))))
+    (ignore-errors
+      (apply (car callback) sexp (cdr callback)))))
 
 (defun irony--server-process-filter (process output)
   "Handle output that come from an irony-server process."

--- a/irony.el
+++ b/irony.el
@@ -588,7 +588,7 @@ list (and undo information is not kept).")
 (defun irony--process-server-response (process response)
   (let ((sexp (read response))
         (callback (irony--server-process-pop-callback process)))
-    (ignore-errors
+    (with-demoted-errors "Warning: %S"
       (apply (car callback) sexp (cdr callback)))))
 
 (defun irony--server-process-filter (process output)


### PR DESCRIPTION
In function `irony--server-process-filter`, when multiple responses are
returned, will call `irony--process-server-response` to process theme on
by one. But if some one of the responses (not the last) signals error in
processing, then `irony--server-process-filter` will be interrupted,
that will leave some responses not processed, and corresponding
callbacks in the process not poped. Then follow-up requests will call
wrong callbacks and waiting in `accept-process-output` forever.

Run `irony-server-kill` manually will clear the callbacks and fix this,
but ignore errors in server response processing will be better