### PR TITLE
substitute rpath with full libclang path on OS X

### DIFF
--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -61,20 +61,20 @@ endforeach()
 
 find_path(LIBCLANG_INCLUDE_DIR clang-c/Index.h
   PATHS ${libclang_llvm_header_search_paths}
-  PATH_SUFFIXES LLVM/include #Windows package from http://llvm.org/releases/
+  PATH_SUFFIXES llvm/include #Windows package from http://llvm.org/releases/
   DOC "The path to the directory that contains clang-c/Index.h")
 
 # On Windows with MSVC, the import library uses the ".imp" file extension
 # instead of the comon ".lib"
 if (MSVC)
   find_file(LIBCLANG_LIBRARY libclang.imp
-    PATH_SUFFIXES LLVM/lib
+    PATH_SUFFIXES llvm/lib
     DOC "The file that corresponds to the libclang library.")
 endif()
 
 find_library(LIBCLANG_LIBRARY NAMES libclang.imp libclang clang
   PATHS ${libclang_llvm_lib_search_paths}
-  PATH_SUFFIXES LLVM/lib #Windows package from http://llvm.org/releases/
+  PATH_SUFFIXES llvm/lib #Windows package from http://llvm.org/releases/
   DOC "The file that corresponds to the libclang library.")
 
 get_filename_component(LIBCLANG_LIBRARY_DIR ${LIBCLANG_LIBRARY} PATH)

--- a/server/src/CMakeLists.txt
+++ b/server/src/CMakeLists.txt
@@ -68,3 +68,12 @@ set_source_files_properties(main.cpp
 target_link_libraries(irony-server ${LIBCLANG_LIBRARIES})
 
 install(TARGETS irony-server DESTINATION bin)
+
+# don't use @rpath
+if (APPLE)
+  add_custom_command(
+    TARGET irony-server
+    POST_BUILD COMMAND
+    ${CMAKE_INSTALL_NAME_TOOL} "-change" "@rpath/libclang.dylib" "${LIBCLANG_LIBRARY}" "$<TARGET_FILE:irony-server>"
+    )
+endif()


### PR DESCRIPTION
The goal here is to ensure that e.g. `@rpath/libclang.dylib` is substituted with the actual `libclang` path discovered at install time, as otherwise `irony-server` will fail to start (unless the rpath is actually set to a path with the libclang library, which I think if often not the case by default).

Note that I tried fiddling with all the rpath-related variables described at https://cmake.org/Wiki/CMake_RPATH_handling, but had no joy in otherwise forcing CMake to generate the binary with an absolute library path.

Let me know what you think -- it also might be better to hide this configuration behind an option, but I think this will help ensure that `irony-server` 'just works' when installed e.g. through `(irony-install-server)` from Emacs.