### PR TITLE
Add support for shell commands in .clang_complete

### DIFF
--- a/irony-cdb-clang-complete.el
+++ b/irony-cdb-clang-complete.el
@@ -46,6 +46,14 @@
 (defun irony-cdb-clang-complete--load-db (cc-file)
   (with-temp-buffer
     (insert-file-contents cc-file)
+    ;; shell eval any forms in backticks
+    (save-excursion
+      (while (re-search-forward "`\\(.*?\\)`" nil t)
+        (replace-match
+         ;; strip newlines
+         (replace-regexp-in-string "\n\\'" ""
+                                   (shell-command-to-string
+                                    (match-string 1))))))
     (list
      (cons
       ;; compile options with trailing whitespaces removed


### PR DESCRIPTION
Any form in .clang_complete contained in backticks (``) will
be evaluated as a shell command. This allows forms such as:

```
-I/lib/modules/`uname -r`
```

to refer to the currently installed Linux kernel module directory.

See Issue #274 for motivation.