### PR TITLE
Implemented irony-cdb-json-select-most-recent.

### DIFF
--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -77,9 +77,6 @@ directories to project directory."
     (let ((elm (nth pos target-list)))
       (append (list elm) (delete elm target-list)))))
 
-(defun irony-cdb-json--cdb-list ()
-  (mapcar #'cdr irony-cdb-json--project-alist))
-
 (defun irony-cdb-json--choose-cdb ()
   "Prompt to select CDB from current project root."
   (let ((proot (irony-cdb-json--find-best-prefix-path

--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -71,6 +71,35 @@ directories to project directory."
   ; and tell irony to load it now
   (irony-cdb-autosetup-compile-options))
 
+(defun irony-cdb-json--put-first (pos target-list)
+  (if (>= pos (length target-list))
+      target-list
+    (let ((elm (nth pos target-list)))
+      (append (list elm) (delete elm target-list)))))
+
+(defun irony-cdb-json--choose-cdb ()
+  (let ((choices (mapcar (lambda (x) (cdr x)) irony-cdb-json--project-alist)))
+    (completing-read "Choose Irony CDB: " choices nil 'require-match nil)))
+
+;;;###autoload
+(defun irony-cdb-json-select ()
+  "Select CDB to use with a prompt.
+
+It is useful when you have several CDBs with the same project
+root.
+
+The completion function used internally is `completing-read' so
+it could easily be used with helm, for instance, by enabling
+`helm-mode' before calling the function."
+  (interactive)
+  (let ((pos (cl-position (irony-cdb-json--choose-cdb)
+                          irony-cdb-json--project-alist
+                          :test (lambda (x y) (string-equal x (cdr y))))))
+    (setq irony-cdb-json--project-alist
+          (irony-cdb-json--put-first pos irony-cdb-json--project-alist))
+    (irony-cdb-json--save-project-alist)
+    (irony-cdb-autosetup-compile-options)))
+
 (defun irony-cdb-json--get-compile-options ()
   (irony--awhen (irony-cdb-json--locate-db)
     (let ((db (irony-cdb-json--load-db it)))

--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -109,28 +109,23 @@ it could easily be used with helm, for instance, by enabling
         (setq irony-cdb-json--project-alist
               (irony-cdb-json--put-first pos irony-cdb-json--project-alist))
         (irony-cdb-json--save-project-alist)
-        (irony-cdb-autosetup-compile-options)
-        (message "%s" (first irony-cdb-json--project-alist))))))
+        (irony-cdb-autosetup-compile-options)))))
 
 (defun irony-cdb-json--last-mod (file)
   (nth 5 (file-attributes file)))
-
-(defun irony-cdb-json--last-mod-cdb ()
-  (let (cdbs result)
-    (progn
-      (setq cdbs (irony-cdb-json--cdb-list))
-      (setq result (first cdbs))
-      (dolist (cdb cdbs)
-        (when (time-less-p (irony-cdb-json--last-mod result)
-                           (irony-cdb-json--last-mod cdb))
-          (setq result cdb)))
-      result)))
 
 ;;;###autoload
 (defun irony-cdb-json-select-most-recent ()
   "Select CDB that is most recently modified."
   (interactive)
-  (irony-cdb-json-select (irony-cdb-json--last-mod-cdb)))
+  ;; Sort list so most recently modified files appear first.
+  (setq irony-cdb-json--project-alist
+        (sort irony-cdb-json--project-alist
+              (lambda (x y)
+                (time-less-p (irony-cdb-json--last-mod (cdr y))
+                             (irony-cdb-json--last-mod (cdr x))))))
+  (irony-cdb-json--save-project-alist)
+  (irony-cdb-autosetup-compile-options))
 
 (defun irony-cdb-json--get-compile-options ()
   (irony--awhen (irony-cdb-json--locate-db)

--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -108,26 +108,21 @@ even helm by enabling `helm-mode' before calling the function."
     (irony-cdb-autosetup-compile-options)))
 
 (defun irony-cdb-json--last-mod (file)
-  (nth 5 (file-attributes file)))
+  "File modification time or null time if file doesn't exist."
+  (or (nth 5 (file-attributes file))
+      '(0 0 0 0)))
 
 ;;;###autoload
 (defun irony-cdb-json-select-most-recent ()
   "Select CDB that is most recently modified."
   (interactive)
-  (let (exists notexists)
-    (dolist (elm irony-cdb-json--project-alist)
-      (if (file-exists-p (cdr elm))
-          (setq exists (append exists (list elm)))
-        (setq notexists (append notexists (list elm)))))
-    ;; Sort list so most recently modified files appear first.
-    (setq exists
-          (sort exists
+    (setq irony-cdb-json--project-alist
+          (sort irony-cdb-json--project-alist
                 (lambda (x y)
                   (time-less-p (irony-cdb-json--last-mod (cdr y))
                                (irony-cdb-json--last-mod (cdr x))))))
-    (setq irony-cdb-json--project-alist (append exists notexists))
     (irony-cdb-json--save-project-alist)
-    (irony-cdb-autosetup-compile-options)))
+    (irony-cdb-autosetup-compile-options))
 
 (defun irony-cdb-json--get-compile-options ()
   (irony--awhen (irony-cdb-json--locate-db)

--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -79,17 +79,13 @@ directories to project directory."
 
 (defun irony-cdb-json--choose-cdb ()
   "Prompt to select CDB from current project root."
-  (let ((proot (irony-cdb-json--find-best-prefix-path
-                (irony-cdb-json--target-path)
-                (mapcar 'car irony-cdb-json--project-alist)))
-        (cdbs '()))
-    (progn
-      (dolist (elm irony-cdb-json--project-alist)
-        (when (string-equal proot (car elm))
-          (setq cdbs (append cdbs (list (cdr elm))))))
-      (if (> (length cdbs) 0)
-          (completing-read "Choose Irony CDB: " cdbs nil 'require-match nil)
-        nil))))
+  (let* ((proot (irony-cdb-json--find-best-prefix-path
+                 (irony-cdb-json--target-path)
+                 (mapcar 'car irony-cdb-json--project-alist)))
+         (cdbs (mapcar 'cdr
+                       (cl-remove-if-not (lambda (x) (string-equal proot (car x)))
+                                         irony-cdb-json--project-alist))))
+    (completing-read "Choose Irony CDB: " cdbs nil 'require-match nil)))
 
 ;;;###autoload
 (defun irony-cdb-json-select ()
@@ -119,8 +115,6 @@ even helm by enabling `helm-mode' before calling the function."
   "Select CDB that is most recently modified."
   (interactive)
   (let (exists notexists)
-    (setq exists '())
-    (setq notexists '())
     (dolist (elm irony-cdb-json--project-alist)
       (if (file-exists-p (cdr elm))
           (setq exists (append exists (list elm)))


### PR DESCRIPTION
It sorts the CDB list so that most recently modified files appear first, which ensures that it works even when having multiple projects with multiple build folders.

As discussed in issue #302.