### PR TITLE
irony-cdb-json: fix compiler flags when using ccache

### DIFF
--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -211,7 +211,7 @@ even helm by enabling `helm-mode' before calling the function."
 
 (defun irony-cdb-json--compile-command-options (compile-command)
   "Return the compile options of COMPILE-COMMAND as a list."
-  (cdr                                  ;remove compiler from returned value
+  (irony-cdb--remove-compiler-from-flags
    (irony--split-command-line (cdr (assq 'command compile-command)))))
 
 (defun irony-cdb-json--adjust-compile-options (compile-options file default-dir)


### PR DESCRIPTION
This commit changes the cleanup of the compiler flags to call `irony-cdb--remove-compiler-from-flags`. This function is used by the `libclang` database to properly remove the compiler from the flags. In particular: it takes into account if the compiler is wrapped by a call to `ccache`.

Similar changes might be needed in other databases to be able to properly support ccache.