### PR TITLE
Improved diagnostics

### DIFF
--- a/irony-diagnostics.el
+++ b/irony-diagnostics.el
@@ -44,6 +44,9 @@
 (defun irony-diagnostics-column (diagnostic)
   (nth 2 diagnostic))
 
+(defun irony-diagnostics-column-end (diagnostic)
+  (nth 3 diagnostic))
+
 (defun irony-diagnostics-severity (diagnostic)
   (nth 4 diagnostic))
 

--- a/server/src/TUManager.cpp
+++ b/server/src/TUManager.cpp
@@ -48,9 +48,15 @@ TUManager::TUManager()
   // significantly slower.
   //
   // -- https://github.com/Sarcasm/irony-mode/issues/4
-  if (CINDEX_VERSION < 6) {
-    parseTUOptions_ &= ~CXTranslationUnit_PrecompiledPreamble;
-  }
+#if CINDEX_VERSION < 6
+  parseTUOptions_ &= ~CXTranslationUnit_PrecompiledPreamble;
+#endif
+
+  // Keep going even after fatal errors, or flycheck-irony will only display the
+  // first error.
+#if CINDEX_VERSION >= 34
+  parseTUOptions_ |= CXTranslationUnit_KeepGoing;
+#endif
 }
 
 TUManager::~TUManager() {

--- a/server/src/TUManager.cpp
+++ b/server/src/TUManager.cpp
@@ -11,6 +11,7 @@
 
 #include "TUManager.h"
 
+#include <algorithm>
 #include <iostream>
 
 TUManager::TUManager()
@@ -105,9 +106,14 @@ TUManager::parse(const std::string &filename,
     argv.push_back(CLANG_BUILTIN_HEADERS_DIR);
 #endif
 
-    for (auto &flag : flags) {
+    // Add spell checking; benefits diagnostics output.
+    if (std::find_if(flags.begin(), flags.end(),
+                     [] (const std::string& arg) { return arg == "-fspell-checking"; })
+        == flags.end())
+      argv.push_back("-fspell-checking");
+
+    for (auto &flag : flags)
       argv.push_back(flag.c_str());
-    }
 
     tu = clang_parseTranslationUnit(
         index_,


### PR DESCRIPTION
Adds spell checking, notes, hints and end column to Irony's diagnostic output.

This rewrites dumpDiagnostics() so that it also finds the end column,  includes notes and fixit hints.

The output format has not changed, but instead of outputting the offset, it now outputs the end column. This field was previously unused, but a new function as been added to irony-diagnostics.el to pick it up.

This rewrite has two goals; find the end column to speed up Flycheck's  error-region for flycheck-irony (separate project and change) and improve diagnostic reporting by including notes and fixit hints.

Notes are kept in child diagnostics, so these are now picked up and parsed as well.

Once parsed, notes are collapsed into their parent if on the same line (since it's mostly extra information about the parent).

Some more filtering is also done to get rid of reference to other files (which are irrelevant for flycheck-irony) and "declared here" notes that will appear out of context before the actual message (usually) when marked by Flycheck.

Messages are changed to also include notes (or'ed together, which seems to work quite well) and a hint, if there is only one and it's not attached to a note (which already spells out what the hint says).

Explanatory comments have been added in the code to clarify what it's trying to achieve.

-fspell-check has been added to the flags that TUManager uses to get libclang to perform spell
checking. This has a performance penalty, but subjective testing indicates it's not too bad the way
Irony works.

I'll continue to run with this for a while for testing purposes. While I've tested it on quite a few
diagnostic messages, there may be others that the current format doesn't work equally well for.
