### PR TITLE
Use ubuntu 14.04 trusty beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,32 @@
 language: cpp
 
-env:
-  matrix:
-    - EMACS=emacs24
-    - EMACS=emacs-snapshot
+sudo: required
+dist: trusty
+
+addons:
+  apt:
+    sources:
+      - cassou-emacs
+      - sourceline: 'ppa:ubuntu-elisp/ppa'
+    packages:
+      - libclang-dev
+      - emacs24
+      - emacs-snapshot
 
 compiler:
   - gcc
   - clang
 
-install:
-  - if [ "$EMACS" = "emacs24" ]; then
-        sudo add-apt-repository -y ppa:cassou/emacs &&
-        sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs24 emacs24-el;
-    fi
-  - if [ "$EMACS" = "emacs-snapshot" ]; then
-        sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
-        sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs-snapshot;
-    fi
-  - sudo apt-get install libclang-dev -qq
+env:
+  - EMACS=emacs24
+  - EMACS=emacs-snapshot
 
 before_script:
   - mkdir build
   - cd build
 
 script:
+  - $EMACS --version
   - cmake -DEMACS_EXECUTABLE=$(which $EMACS) ../server
   - make -k
   - make check


### PR DESCRIPTION
https://docs.travis-ci.com/user/trusty-ci-environment

Trusty beta build environment provides modern C++ compiler to build irony-server.
(GCC 4.6.3 -> 4.8.4 and Clang 3.4 -> 3.5.0)

Build result here
https://travis-ci.org/kosh04/irony-mode/builds/149803944

And refer to #324 to resolve the build job `EMACS=emacs24` fails.