### PR TITLE
Don't quote compiler arguments.

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -337,6 +337,10 @@ breaks with escaped quotes in compile_commands.json, such as in:
       (setq args (cons (apply 'string (nreverse cur-arg)) args)))
     (nreverse args)))
 
+(defun irony--combine-strings (strings)
+  "Join STRINGS with one space between every two elements."
+  (mapconcat 'identity strings " "))
+
 
 ;;
 ;; Mode
@@ -649,7 +653,7 @@ If no such file exists on the filesystem the special file '-' is
       (irony--without-narrowing
         (process-send-string process
                              (format "%s\n"
-                                     (combine-and-quote-strings argv)))))))
+                                     (irony--combine-strings argv)))))))
 
 (defvar irony--sync-id 0 "ID of next sync request.")
 (defvar irony--sync-result '(-1 . nil)
@@ -699,8 +703,8 @@ care of."
         ;; http://www.gnu.org/software/emacs/manual/html_node/elisp/Input-to-Processes.html).
         (process-send-string process
                              (format "%s\n%s\n%s\n%d\n%s\n"
-                                     (combine-and-quote-strings argv)
-                                     (combine-and-quote-strings compile-options)
+                                     (irony--combine-strings argv)
+                                     (irony--combine-strings compile-options)
                                      buffer-file-name
                                      (irony--buffer-size-in-bytes)
                                      (buffer-substring (point-min) (point-max))))))))


### PR DESCRIPTION
This is sort of what the code does at the moment:
`(insert
 (combine-and-quote-strings '("-DMY_VAR=\"foo\"" "--std=c++11")))`
which becomes
`"-DMY_VAR=\"foo\"" --std=c++11`

This changes it to do
`(insert
 (mapconcat 'identity '("-DMY_VAR=\"foo\"" "--std=c++11") " "))`
becoming the desired
`-DMY_VAR="foo" --std=c++11`