### PR TITLE
Fixed compatibility with Gentoo's clang-4 installation directories.

### DIFF
--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -16,7 +16,7 @@
 # most recent versions come first
 # http://llvm.org/apt/
 set(LIBCLANG_KNOWN_LLVM_VERSIONS 5.0.0 5.0
-  4.0.0 4.0
+  4.0.0 4.0 4
   3.9.1 3.9.0 3.9
   3.8.1 3.8.0 3.8
   3.7.1 3.7.0 3.7
@@ -46,6 +46,8 @@ foreach (version ${LIBCLANG_KNOWN_LLVM_VERSIONS})
     "/usr/local/lib/llvm-${version}/include"
     # FreeBSD ports versions
     "/usr/local/llvm${undotted_version}/include"
+    # Gentoo clang-4
+    "/usr/lib/llvm/${version}/include"
     )
 
   list(APPEND libclang_llvm_lib_search_paths
@@ -59,6 +61,9 @@ foreach (version ${LIBCLANG_KNOWN_LLVM_VERSIONS})
     "/usr/local/lib/llvm-${version}/lib"
     # FreeBSD ports versions
     "/usr/local/llvm${undotted_version}/lib"
+    # Gentoo clang-4
+    "/usr/lib/llvm/${version}/lib"
+    "/usr/lib/llvm/${version}/lib64"
     )
 endforeach()
 

--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -63,7 +63,6 @@ foreach (version ${LIBCLANG_KNOWN_LLVM_VERSIONS})
     "/usr/local/llvm${undotted_version}/lib"
     # Gentoo clang-4
     "/usr/lib/llvm/${version}/lib"
-    "/usr/lib/llvm/${version}/lib64"
     )
 endforeach()
 


### PR DESCRIPTION
With llvm-4, Gentoo has a different directory versioning scheme. Index.h and libclang.so are located in:

     ~ $ find /usr/lib/llvm -name Index.h -or -name libclang.so
    /usr/lib/llvm/4/include/clang-c/Index.h
    /usr/lib/llvm/4/lib64/libclang.so

I don't know that this is the best way to solve this problem.