### PR TITLE
Re-instate sentinal

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -620,6 +620,7 @@ list (and undo information is not kept).")
                     (format-time-string "irony.%Y-%m-%d_%Hh-%Mm-%Ss.log")
                     temporary-file-directory))))
     (set-process-query-on-exit-flag process nil)
+    (set-process-sentinel process 'irony--server-process-sentinel)
     (irony-iotask-setup-process process)
     process))
 


### PR DESCRIPTION
This may seem like an obscure request, but it is actually due to: #358.

I concede that I have not yet tracked down issue 358 (and I will look into this the next chance I get!). Stopping irony-mode and restarting is the only way to remove obscure references that appear after the process has been active for a while (though this does not happen to me often); anyway, this issue is not about 358. I would like to request the patch above because when I kill irony I like to see the mini-buffer text.