### PR TITLE
Add 'prefix' filtering for 'candidates' command.

### DIFF
--- a/irony-completion.el
+++ b/irony-completion.el
@@ -231,6 +231,11 @@ that can be validly accessed are deemed not-accessible."
            irony-completion-availability-filter))
    candidates))
 
+(defun irony-completion-make-prefix (prefix)
+  (if (and prefix (not (string= prefix "")))
+      prefix
+    "*"))
+
 (defun irony-completion-candidates (&optional prefix)
   "Return the list of candidates at point.
 
@@ -252,13 +257,16 @@ A candidate is composed of the following elements:
  7. The availability of the candidate."
   (irony--awhen (irony-completion-symbol-bounds)
     (irony-completion--filter-candidates
-     (irony--run-task (irony--candidates-task nil (car it))))))
+     (irony--run-task
+      (irony--candidates-task nil (car it)
+                              (irony-completion-make-prefix))))))
 
 (defun irony-completion-candidates-async (callback &optional prefix)
   (irony--aif (irony-completion-symbol-bounds)
       (lexical-let ((cb callback))
         (irony--run-task-asynchronously
-         (irony--candidates-task nil (car it) (or prefix ""))
+         (irony--candidates-task nil (car it)
+                                 (irony-completion-make-prefix prefix))
          (lambda (candidates-result)
            (funcall cb (irony-completion--filter-candidates
                         (irony-iotask-result-get candidates-result))))))

--- a/irony-completion.el
+++ b/irony-completion.el
@@ -185,14 +185,14 @@ that can be validly accessed are deemed not-accessible."
 
 (irony-iotask-define-task irony--t-candidates
   "`candidates' server command."
-  :start (lambda ()
-           (irony--server-send-command "candidates"))
+  :start (lambda (prefix)
+           (irony--server-send-command "candidates" prefix))
   :update irony--server-query-update)
 
-(defun irony--candidates-task (&optional buffer pos)
+(defun irony--candidates-task (&optional buffer pos prefix)
   (irony-iotask-chain
    (irony--complete-task buffer pos)
-   (irony-iotask-package-task irony--t-candidates)))
+   (irony-iotask-package-task irony--t-candidates prefix)))
 
 
 ;;
@@ -231,7 +231,7 @@ that can be validly accessed are deemed not-accessible."
            irony-completion-availability-filter))
    candidates))
 
-(defun irony-completion-candidates ()
+(defun irony-completion-candidates (&optional prefix)
   "Return the list of candidates at point.
 
 A candidate is composed of the following elements:
@@ -254,11 +254,11 @@ A candidate is composed of the following elements:
     (irony-completion--filter-candidates
      (irony--run-task (irony--candidates-task nil (car it))))))
 
-(defun irony-completion-candidates-async (callback)
+(defun irony-completion-candidates-async (callback &optional prefix)
   (irony--aif (irony-completion-symbol-bounds)
       (lexical-let ((cb callback))
         (irony--run-task-asynchronously
-         (irony--candidates-task nil (car it))
+         (irony--candidates-task nil (car it) (or prefix ""))
          (lambda (candidates-result)
            (funcall cb (irony-completion--filter-candidates
                         (irony-iotask-result-get candidates-result))))))

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -103,6 +103,7 @@ std::ostream &operator<<(std::ostream &os, const Command &command) {
      << "dir='" << command.dir << "', "
      << "line=" << command.line << ", "
      << "column=" << command.column << ", "
+     << "prefix=" << command.prefix << ", "
      << "flags=[";
   bool first = true;
   for (const std::string &flag : command.flags) {
@@ -178,6 +179,8 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     break;
 
   case Command::Candidates:
+    positionalArgs.push_back(StringConverter(&command_.prefix));
+    break;
   case Command::CompletionDiagnostics:
   case Command::Diagnostics:
   case Command::Help:
@@ -204,7 +207,7 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     command_.flags.assign(std::next(argsEnd), argv.end());
   }
 
-  if (argCount != static_cast<int>(positionalArgs.size())) {
+  if (argCount < static_cast<int>(positionalArgs.size())) {
     std::clog << "error: invalid number of arguments for '" << actionStr
               << "' (requires " << positionalArgs.size() << " got " << argCount
               << ")\n";

--- a/server/src/Command.h
+++ b/server/src/Command.h
@@ -32,6 +32,7 @@ struct Command {
     file.clear();
     unsavedFile.clear();
     dir.clear();
+    prefix.clear();
     line = 0;
     column = 0;
     opt = false;
@@ -46,6 +47,7 @@ struct Command {
   std::string file;
   std::string unsavedFile;
   std::string dir;
+  std::string prefix;
   unsigned line;
   unsigned column;
   bool opt;

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -309,7 +309,7 @@ void Irony::completionDiagnostics() const {
   std::cout << ")\n";
 }
 
-void Irony::candidates() const {
+void Irony::candidates(const std::string &prefix) const {
   if (activeCompletionResults_ == nullptr) {
     std::cout << "nil\n";
     return;
@@ -431,6 +431,13 @@ void Irony::candidates() const {
         // annotation is what comes after the typedtext
         annotationStart = prototype.size();
         typedTextSet = true;
+      }
+    }
+    if (prefix != "" && prefix != "*") {
+      auto res = std::mismatch(prefix.begin(), prefix.end(), typedtext.begin());
+      if (res.first != prefix.end()) {
+        // typedText doesn't have prefix of 'prefix'
+        continue;
       }
     }
 

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -100,7 +100,7 @@ public:
   /// Get all the completion candidates.
   ///
   /// \pre complete() was called.
-  void candidates() const;
+  void candidates(const std::string &prefix) const;
 
   /// Get the diagnostics produced by the last \c complete().
   ///

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -181,7 +181,7 @@ int main(int ac, const char *av[]) {
       break;
 
     case Command::Candidates:
-      irony.candidates();
+      irony.candidates(c->prefix);
       break;
 
     case Command::CompletionDiagnostics:


### PR DESCRIPTION
This commit adds prefix parameter for candidates.
In irony-server, it will filter the completion results before sending them to client.
Prefix "*" is treated as no filtering (return all completions results) as I can't find a easy way to support optional parameter in irony-server

We still need modify company-irony to support. Since it is in another respository, the fix doesn't contain the modification.
