### PR TITLE
Add prefix filter for 'candidates' commands

### DIFF
--- a/irony-completion.el
+++ b/irony-completion.el
@@ -185,14 +185,14 @@ that can be validly accessed are deemed not-accessible."
 
 (irony-iotask-define-task irony--t-candidates
   "`candidates' server command."
-  :start (lambda ()
-           (irony--server-send-command "candidates"))
+  :start (lambda (prefix)
+           (irony--server-send-command "candidates" prefix))
   :update irony--server-query-update)
 
-(defun irony--candidates-task (&optional buffer pos)
+(defun irony--candidates-task (&optional buffer pos prefix)
   (irony-iotask-chain
    (irony--complete-task buffer pos)
-   (irony-iotask-package-task irony--t-candidates)))
+   (irony-iotask-package-task irony--t-candidates prefix)))
 
 
 ;;
@@ -231,7 +231,12 @@ that can be validly accessed are deemed not-accessible."
            irony-completion-availability-filter))
    candidates))
 
-(defun irony-completion-candidates ()
+(defun irony-completion-make-prefix (prefix)
+  (if (and prefix (not (string= prefix "")))
+      prefix
+    "*"))
+
+(defun irony-completion-candidates (&optional prefix)
   "Return the list of candidates at point.
 
 A candidate is composed of the following elements:
@@ -252,13 +257,16 @@ A candidate is composed of the following elements:
  7. The availability of the candidate."
   (irony--awhen (irony-completion-symbol-bounds)
     (irony-completion--filter-candidates
-     (irony--run-task (irony--candidates-task nil (car it))))))
+     (irony--run-task
+      (irony--candidates-task nil (car it)
+                              (irony-completion-make-prefix))))))
 
-(defun irony-completion-candidates-async (callback)
+(defun irony-completion-candidates-async (callback &optional prefix)
   (irony--aif (irony-completion-symbol-bounds)
       (lexical-let ((cb callback))
         (irony--run-task-asynchronously
-         (irony--candidates-task nil (car it))
+         (irony--candidates-task nil (car it)
+                                 (irony-completion-make-prefix prefix))
          (lambda (candidates-result)
            (funcall cb (irony-completion--filter-candidates
                         (irony-iotask-result-get candidates-result))))))

--- a/irony-completion.el
+++ b/irony-completion.el
@@ -186,8 +186,12 @@ that can be validly accessed are deemed not-accessible."
 (irony-iotask-define-task irony--t-candidates
   "`candidates' server command."
   :start (lambda (prefix ignore-case)
-           (irony--server-send-command "candidates" prefix
-                                       (if ignore-case "on" "off")))
+           (irony--server-send-command
+            "candidates" prefix
+            (cond
+             ((not ignore-case) "")
+             ((eq ignore-case 'smart) "smart")
+             (t "insensitive"))))
   :update irony--server-query-update)
 
 (defun irony--candidates-task (&optional buffer pos prefix ignore-case)

--- a/irony.el
+++ b/irony.el
@@ -646,6 +646,13 @@ list (and undo information is not kept).")
   (irony-iotask-schedule (irony--get-server-process-create) task callback))
 
 (defun irony--quote-strings (strings &optional separator)
+  "Like `combine-and-quote-strings', but when the string is \"\" or nil,
+`irony--quote-strings' will convert it to \"\" instead of <SPC>.
+That is:
+
+  (irony--quote-strings \'(\"a\" \"\" \"b\"))            => \"a \\\"\\\" b\"
+  (combine-and-quote-strings \'(\"a\" \"\" \"b\"))       => \"a  b\"
+"
   (let* ((sep (or separator " "))
          (re (concat "[\\\"]" "\\|" (regexp-quote sep))))
     (mapconcat

--- a/irony.el
+++ b/irony.el
@@ -645,8 +645,21 @@ list (and undo information is not kept).")
 (defun irony--run-task-asynchronously (task callback)
   (irony-iotask-schedule (irony--get-server-process-create) task callback))
 
+(defun irony--quote-strings (strings &optional separator)
+  (let* ((sep (or separator " "))
+         (re (concat "[\\\"]" "\\|" (regexp-quote sep))))
+    (mapconcat
+     (lambda (str)
+       (cond
+        ((or (not str) (string= str ""))
+         "\"\"")
+        ((string-match re str)
+         (concat "\"" (replace-regexp-in-string "[\\\"]" "\\\\\\&" str) "\""))
+        (t str)))
+     strings sep)))
+
 (defun irony--server-send-command (command &rest args)
-  (let ((command-line (concat (combine-and-quote-strings
+  (let ((command-line (concat (irony--quote-strings
                                (mapcar (lambda (arg)
                                          (if (numberp arg)
                                              (number-to-string arg)

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -180,6 +180,7 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
 
   case Command::Candidates:
     positionalArgs.push_back(StringConverter(&command_.prefix));
+    positionalArgs.push_back(OptionConverter(&command_.opt));
     break;
   case Command::CompletionDiagnostics:
   case Command::Diagnostics:
@@ -207,7 +208,7 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     command_.flags.assign(std::next(argsEnd), argv.end());
   }
 
-  if (argCount < static_cast<int>(positionalArgs.size())) {
+  if (argCount != static_cast<int>(positionalArgs.size())) {
     std::clog << "error: invalid number of arguments for '" << actionStr
               << "' (requires " << positionalArgs.size() << " got " << argCount
               << ")\n";

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -103,6 +103,7 @@ std::ostream &operator<<(std::ostream &os, const Command &command) {
      << "dir='" << command.dir << "', "
      << "line=" << command.line << ", "
      << "column=" << command.column << ", "
+     << "prefix=" << command.prefix << ", "
      << "flags=[";
   bool first = true;
   for (const std::string &flag : command.flags) {
@@ -178,6 +179,8 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     break;
 
   case Command::Candidates:
+    positionalArgs.push_back(StringConverter(&command_.prefix));
+    break;
   case Command::CompletionDiagnostics:
   case Command::Diagnostics:
   case Command::Help:
@@ -204,7 +207,7 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
     command_.flags.assign(std::next(argsEnd), argv.end());
   }
 
-  if (argCount != static_cast<int>(positionalArgs.size())) {
+  if (argCount < static_cast<int>(positionalArgs.size())) {
     std::clog << "error: invalid number of arguments for '" << actionStr
               << "' (requires " << positionalArgs.size() << " got " << argCount
               << ")\n";

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -103,7 +103,8 @@ std::ostream &operator<<(std::ostream &os, const Command &command) {
      << "dir='" << command.dir << "', "
      << "line=" << command.line << ", "
      << "column=" << command.column << ", "
-     << "prefix=" << command.prefix << ", "
+     << "prefix='" << command.prefix << "', "
+     << "caseStyle='" << command.caseStyle << "', "
      << "flags=[";
   bool first = true;
   for (const std::string &flag : command.flags) {
@@ -180,7 +181,7 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
 
   case Command::Candidates:
     positionalArgs.push_back(StringConverter(&command_.prefix));
-    positionalArgs.push_back(OptionConverter(&command_.opt));
+    positionalArgs.push_back(StringConverter(&command_.caseStyle));
     break;
   case Command::CompletionDiagnostics:
   case Command::Diagnostics:

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -83,7 +83,7 @@ private:
   bool *dest_;
 };
 
-const std::map<std::string, PrefixMatchStyle> prefixMatchStyleMap = {
+const std::map<std::string, PrefixMatchStyle> PREFIX_MATCH_STYLE_MAP = {
   { "exact", PrefixMatchStyle::Exact },
   { "case-insensitive", PrefixMatchStyle::CaseInsensitive },
   { "smart-case", PrefixMatchStyle::SmartCase},
@@ -95,9 +95,9 @@ struct PrefixMatchStyleConverter {
   }
 
   bool operator()(const std::string &str) {
-    auto res = prefixMatchStyleMap.find(str);
+    auto res = PREFIX_MATCH_STYLE_MAP.find(str);
 
-    if (res == prefixMatchStyleMap.cend()) {
+    if (res == PREFIX_MATCH_STYLE_MAP.cend()) {
       return false;
     }
     *dest_ = res->second;
@@ -109,7 +109,7 @@ private:
 };
 
 std::ostream &operator<<(std::ostream &os, PrefixMatchStyle style) {
-  for (auto it : prefixMatchStyleMap) {
+  for (auto it : PREFIX_MATCH_STYLE_MAP) {
     if (it.second == style) {
       os << it.first;
       return os;

--- a/server/src/Command.h
+++ b/server/src/Command.h
@@ -33,6 +33,7 @@ struct Command {
     unsavedFile.clear();
     dir.clear();
     prefix.clear();
+    caseStyle.clear();
     line = 0;
     column = 0;
     opt = false;

--- a/server/src/Command.h
+++ b/server/src/Command.h
@@ -13,6 +13,7 @@
 
 #include "support/CIndex.h"
 #include "support/TemporaryFile.h"
+#include "Style.h"
 
 #include <iosfwd>
 #include <string>
@@ -33,7 +34,7 @@ struct Command {
     unsavedFile.clear();
     dir.clear();
     prefix.clear();
-    caseStyle.clear();
+    style = PrefixMatchStyle::Exact;
     line = 0;
     column = 0;
     opt = false;
@@ -49,7 +50,7 @@ struct Command {
   std::string unsavedFile;
   std::string dir;
   std::string prefix;
-  std::string caseStyle;
+  PrefixMatchStyle style;
   unsigned line;
   unsigned column;
   bool opt;

--- a/server/src/Command.h
+++ b/server/src/Command.h
@@ -32,6 +32,7 @@ struct Command {
     file.clear();
     unsavedFile.clear();
     dir.clear();
+    prefix.clear();
     line = 0;
     column = 0;
     opt = false;
@@ -46,6 +47,7 @@ struct Command {
   std::string file;
   std::string unsavedFile;
   std::string dir;
+  std::string prefix;
   unsigned line;
   unsigned column;
   bool opt;

--- a/server/src/Command.h
+++ b/server/src/Command.h
@@ -48,6 +48,7 @@ struct Command {
   std::string unsavedFile;
   std::string dir;
   std::string prefix;
+  std::string caseStyle;
   unsigned line;
   unsigned column;
   bool opt;

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -14,7 +14,7 @@
 
 X(Candidates, "candidates",
   "PREFIX STYLE - print completion candidates (require previous complete). "
-  "STYLE is \"\", \"insensitive\" or \"smart\"")
+  "STYLE is \"exact\", \"case-insensitive\" or \"smart-case\"")
 X(Complete, "complete",
   "FILE LINE COL [-- [COMPILE_OPTIONS...]] - perform code completion at a given location")
 X(CompletionDiagnostics, "completion-diagnostics",

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -12,7 +12,9 @@
 #error Please define the 'X(id, command, description)' macro before inclusion!
 #endif
 
-X(Candidates, "candidates", "print completion candidates (require previous complete)")
+X(Candidates, "candidates",
+  "PREFIX STYLE - print completion candidates (require previous complete). "
+  "STYLE is \"\", \"insensitive\" or \"smart\"")
 X(Complete, "complete",
   "FILE LINE COL [-- [COMPILE_OPTIONS...]] - perform code completion at a given location")
 X(CompletionDiagnostics, "completion-diagnostics",

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -315,21 +315,17 @@ static bool startsWith(const std::string& str, const std::string &prefix, bool c
   return true;
 }
 
-static bool isCaseSensitive(const std::string &prefix, Irony::CaseStyle caseStyle)
+static bool isCaseSensitive(const std::string &prefix, std::string caseStyle)
 {
-  switch (caseStyle) {
-  case Irony::CaseSensitive:
+  if (caseStyle == "" || caseStyle == "nil") {
     return true;
-  case Irony::CaseInsensitive:
-    return false;
-  case Irony::CaseSmart:
-    // In smart style, any uppercase letter indicates case-sensitive
-    return hasUppercase(prefix);
-  default:
-    break;
   }
-  // Shouldn't go here. return case sensitive by default.
-  return true;
+  if (caseStyle == "smart") {
+    return hasUppercase(prefix);
+  }
+
+  // if style is non-nil, always do case-insensitive matching
+  return false;
 }
 
 } // unnamed namespace
@@ -357,7 +353,7 @@ void Irony::completionDiagnostics() const {
   std::cout << ")\n";
 }
 
-void Irony::candidates(const std::string &prefix, CaseStyle caseStyle) const {
+void Irony::candidates(const std::string &prefix, std::string caseStyle) const {
   if (activeCompletionResults_ == nullptr) {
     std::cout << "nil\n";
     return;

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -290,8 +290,8 @@ namespace {
 
 bool hasUppercase(const std::string &prefix)
 {
-  for (auto it = prefix.begin(); it != prefix.end(); ++it) {
-    if (std::isupper(*it)) {
+  for (char c : prefix) {
+    if (std::isupper(c)) {
       return true;
     }
   }

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -291,13 +291,13 @@ static bool iequal(const char a, const char b)
   return std::tolower(a) == std::tolower(b);
 }
 
-static bool startsWith(const std::string& str, const std::string &prefix, bool ignore_case)
+static bool startsWith(const std::string& str, const std::string &prefix, bool ignoreCase)
 {
   if (str.length() < prefix.length()) {
     return false;
   }
   std::pair<std::string::const_iterator, std::string::const_iterator> res;
-  if (!ignore_case) {
+  if (!ignoreCase) {
     res = std::mismatch(prefix.begin(), prefix.end(), str.begin());
   } else {
     res = std::mismatch(prefix.begin(), prefix.end(), str.begin(), iequal);
@@ -331,7 +331,7 @@ void Irony::completionDiagnostics() const {
   std::cout << ")\n";
 }
 
-void Irony::candidates(const std::string &prefix, bool ignore_case) const {
+void Irony::candidates(const std::string &prefix, bool ignoreCase) const {
   if (activeCompletionResults_ == nullptr) {
     std::cout << "nil\n";
     return;
@@ -451,7 +451,7 @@ void Irony::candidates(const std::string &prefix, bool ignore_case) const {
       // https://github.com/Sarcasm/irony-mode/pull/78#issuecomment-37115538
       if (chunkKind == CXCompletionChunk_TypedText && !typedTextSet) {
         typedtext = chunk.text();
-        if (!startsWith(typedtext, prefix, ignore_case)) {
+        if (!startsWith(typedtext, prefix, ignoreCase)) {
           hasPrefix = false;
           break;
         }

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -309,7 +309,7 @@ void Irony::completionDiagnostics() const {
   std::cout << ")\n";
 }
 
-void Irony::candidates() const {
+void Irony::candidates(const std::string &prefix) const {
   if (activeCompletionResults_ == nullptr) {
     std::cout << "nil\n";
     return;
@@ -431,6 +431,13 @@ void Irony::candidates() const {
         // annotation is what comes after the typedtext
         annotationStart = prototype.size();
         typedTextSet = true;
+      }
+    }
+    if (prefix != "" && prefix != "*") {
+      auto res = std::mismatch(prefix.begin(), prefix.end(), typedtext.begin());
+      if (res.first != prefix.end()) {
+        // typedText doesn't have prefix of 'prefix'
+        continue;
       }
     }
 

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -100,7 +100,7 @@ public:
   /// Get all the completion candidates.
   ///
   /// \pre complete() was called.
-  void candidates() const;
+  void candidates(const std::string &prefix) const;
 
   /// Get the diagnostics produced by the last \c complete().
   ///

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -26,6 +26,11 @@ public:
   // use std::string over std::vector<char> because I have some doubts
   // that libclang expect unsaved buffers to be a null terminated C strings
   typedef std::string UnsavedBuffer;
+  enum CaseStyle {
+    CaseSensitive,
+    CaseInsensitive,
+    CaseSmart,
+  };
 
 public:
   Irony();
@@ -100,7 +105,7 @@ public:
   /// Get all the completion candidates.
   ///
   /// \pre complete() was called.
-  void candidates(const std::string &prefix, bool ignoreCase) const;
+  void candidates(const std::string &prefix, CaseStyle caseStyle) const;
 
   /// Get the diagnostics produced by the last \c complete().
   ///

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -100,7 +100,7 @@ public:
   /// Get all the completion candidates.
   ///
   /// \pre complete() was called.
-  void candidates(const std::string &prefix, bool ignore_case) const;
+  void candidates(const std::string &prefix, bool ignoreCase) const;
 
   /// Get the diagnostics produced by the last \c complete().
   ///

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -18,6 +18,8 @@
 
 #include "TUManager.h"
 
+#include "Style.h"
+
 #include <string>
 #include <vector>
 
@@ -100,7 +102,7 @@ public:
   /// Get all the completion candidates.
   ///
   /// \pre complete() was called.
-  void candidates(const std::string &prefix, const std::string caseStyle) const;
+  void candidates(const std::string &prefix, PrefixMatchStyle style) const;
 
   /// Get the diagnostics produced by the last \c complete().
   ///

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -26,11 +26,6 @@ public:
   // use std::string over std::vector<char> because I have some doubts
   // that libclang expect unsaved buffers to be a null terminated C strings
   typedef std::string UnsavedBuffer;
-  enum CaseStyle {
-    CaseSensitive,
-    CaseInsensitive,
-    CaseSmart,
-  };
 
 public:
   Irony();
@@ -105,7 +100,7 @@ public:
   /// Get all the completion candidates.
   ///
   /// \pre complete() was called.
-  void candidates(const std::string &prefix, CaseStyle caseStyle) const;
+  void candidates(const std::string &prefix, const std::string caseStyle) const;
 
   /// Get the diagnostics produced by the last \c complete().
   ///

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -100,7 +100,7 @@ public:
   /// Get all the completion candidates.
   ///
   /// \pre complete() was called.
-  void candidates(const std::string &prefix) const;
+  void candidates(const std::string &prefix, bool ignore_case) const;
 
   /// Get the diagnostics produced by the last \c complete().
   ///

--- a/server/src/Style.h
+++ b/server/src/Style.h
@@ -1,0 +1,17 @@
+/**-*-C++-*-
+ * \file
+ *
+ * \brief Style definition.
+ *
+ * This file is distributed under the GNU General Public License. See
+ * COPYING for details.
+ */
+#ifndef IRONY_MODE_SERVER_STYLE_H_
+#define IRONY_MODE_SERVER_STYLE_H_
+
+enum class PrefixMatchStyle {
+  Exact, CaseInsensitive, SmartCase,
+};
+
+
+#endif //IRONY_MODE_SERVER_STYLE_H_

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -181,7 +181,7 @@ int main(int ac, const char *av[]) {
       break;
 
     case Command::Candidates:
-      irony.candidates(c->prefix);
+      irony.candidates(c->prefix, c->opt);
       break;
 
     case Command::CompletionDiagnostics:

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -102,7 +102,6 @@ private:
   std::streambuf *rdbuf_;
 };
 
-
 int main(int ac, const char *av[]) {
   std::vector<std::string> argv(&av[1], &av[ac]);
 
@@ -182,7 +181,7 @@ int main(int ac, const char *av[]) {
       break;
 
     case Command::Candidates:
-      irony.candidates(c->prefix, c->caseStyle);
+      irony.candidates(c->prefix, c->style);
       break;
 
     case Command::CompletionDiagnostics:

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -181,7 +181,7 @@ int main(int ac, const char *av[]) {
       break;
 
     case Command::Candidates:
-      irony.candidates();
+      irony.candidates(c->prefix);
       break;
 
     case Command::CompletionDiagnostics:

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -102,20 +102,6 @@ private:
   std::streambuf *rdbuf_;
 };
 
-static Irony::CaseStyle parseCaseStyle(const std::string& style)
-{
-  if (style == "nil" || style == "") {
-    return Irony::CaseSensitive;
-  }
-  if (style == "insensitive") {
-    return Irony::CaseInsensitive;
-  }
-  if (style == "smart") {
-    return Irony::CaseSmart;
-  }
-  std::clog << "Unknown case style: " << style << std::endl;
-  return Irony::CaseSensitive;
-}
 
 int main(int ac, const char *av[]) {
   std::vector<std::string> argv(&av[1], &av[ac]);
@@ -196,7 +182,7 @@ int main(int ac, const char *av[]) {
       break;
 
     case Command::Candidates:
-      irony.candidates(c->prefix, parseCaseStyle(c->caseStyle));
+      irony.candidates(c->prefix, c->caseStyle);
       break;
 
     case Command::CompletionDiagnostics:

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -102,6 +102,21 @@ private:
   std::streambuf *rdbuf_;
 };
 
+static Irony::CaseStyle parseCaseStyle(const std::string& style)
+{
+  if (style == "nil" || style == "") {
+    return Irony::CaseSensitive;
+  }
+  if (style == "insensitive") {
+    return Irony::CaseInsensitive;
+  }
+  if (style == "smart") {
+    return Irony::CaseSmart;
+  }
+  std::clog << "Unknown case style: " << style << std::endl;
+  return Irony::CaseSensitive;
+}
+
 int main(int ac, const char *av[]) {
   std::vector<std::string> argv(&av[1], &av[ac]);
 
@@ -181,7 +196,7 @@ int main(int ac, const char *av[]) {
       break;
 
     case Command::Candidates:
-      irony.candidates(c->prefix, c->opt);
+      irony.candidates(c->prefix, parseCaseStyle(c->caseStyle));
       break;
 
     case Command::CompletionDiagnostics:


### PR DESCRIPTION
This commit adds prefix parameter for candidates.
In irony-server, it will filter the completion results before sending them to client.
Prefix "*" is treated as no filtering (return all completions results) as I can't find an easy way to support optional parameter in irony-server

We still need modify company-irony to support. Since it is in another respository, the fix doesn't contain the modification.