### PR TITLE
Check for and use the arguments array in the command json

### DIFF
--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -212,7 +212,10 @@ even helm by enabling `helm-mode' before calling the function."
 (defun irony-cdb-json--compile-command-options (compile-command)
   "Return the compile options of COMPILE-COMMAND as a list."
   (irony-cdb--remove-compiler-from-flags
-   (irony--split-command-line (cdr (assq 'command compile-command)))))
+   (let ((arguments (alist-get 'arguments compile-command)))
+     (if arguments
+         (append arguments nil)
+       (irony--split-command-line (cdr (assq 'command compile-command)))))))
 
 (defun irony-cdb-json--adjust-compile-options (compile-options file default-dir)
   "Adjust COMPILE-OPTIONS to only use options useful for parsing.


### PR DESCRIPTION
Hey there, I ran into an issue using irony with the compile_commands.json generated by `intercept-build` from the scan-build pip package. My elisp-foo is not exactly expert level, but this patch seems to work for me so I thought I'd open a PR.

**The Issue**

`intercept-build` generates a compile_commands.json without the "command" field, but with an "arguments" array:

```JSON
[
    {
        "arguments": [
            "cc", 
            "-c", 
            "-g", 
            "-std=gnu99", 
            "-O3", 
            "-Wall", 
            "-Werror-implicit-function-declaration", 
            "-Wdeclaration-after-statement", 
            "-Wwrite-strings", 
            "-g3", 
            "-O0", 
            "-DMRB_DEBUG", 
            "-I/Users/jbreeden/projects/mruby.d/mruby/include", 
            "-o", 
            "/Users/jbreeden/projects/mruby.d/mruby/build/test/src/range.o", 
            "src/range.c"
        ], 
        "directory": "/Users/jbreeden/projects/mruby.d/mruby", 
        "file": "src/range.c"
    },
...
] 
```

This prevented me from getting completion results correctly. My cmake projects generate a file with the "command" string, and all works as expected. So, I've just added a check for the arguments field before trying to read the command.

What do you think?

For reference, here is some metadata for my scan-build installation:

Metadata-Version: 2.0
Name: scan-build
Version: 2.0.8
Summary: static code analyzer wrapper for Clang.
Home-page: https://github.com/rizsotto/scan-build
Author: László Nagy