### PR TITLE
Fix bogus "irony-server is broken! Invalid version syntax" messages

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -567,7 +567,8 @@ found."
                           exec-path))
          (exe (executable-find "irony-server")))
     (condition-case err
-        (let ((version (car (process-lines exe "--version"))))
+        (let ((version (car (mapcar #'string-trim-right
+                                    (process-lines exe "--version")))))
           (if (and (string-match "^irony-server version " version)
                    (version= (irony-version)
                              (substring version


### PR DESCRIPTION
On Windows, the following diagnostic could incorrectly appear due to line-ending differences (notice the `^M`):

```
Error while checking syntax automatically: (irony-server-error "irony-server is broken! Invalid version syntax: ‘1.2.0^M’")
```