### PR TITLE
Fix a bug when new files are created for the first time

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -751,7 +751,9 @@ That is:
     (cond
      ((irony--buffer-state-modified new) 'set-unsaved)
      ((null old) nil)                   ;noop
-     ((irony--buffer-state-modified old) 'reset-unsaved))))
+     ((and
+       (irony--buffer-state-modified old)
+       (irony--buffer-state-exists old)) 'reset-unsaved))))
 
 (irony-iotask-define-task irony--t-set-unsaved
   "`set-unsaved' server command."


### PR DESCRIPTION
## Bug Reproduction
1. Have Irony and Flycheck enabled
2. Create a new file using `find-file`
3. Write some text and save the file

## Environment
Emacs 26.1 RC1 (prebuilt by https://emacsformacosx.com/)
macOS High Sierra Version 10.13.4

## What Happens
Flycheck gives out the following error in `*Messages*` buffer:

> Error from syntax checker irony: Bad I/O task data: #s(irony-iotask-packaged-task (:start (lambda (process buffer) (if (assq buffer (process-get process :unsaved-buffers)) (irony--server-send-command "reset-unsaved" (irony--get-buffer-path-for-server buffer)) (irony-iotask-set-result t))) :update irony--server-command-update :finish (lambda (process buffer) (process-put process :unsaved-buffers (assq-delete-all buffer (process-get process :unsaved-buffers))))) (#<process Irony> #<buffer abcd.cpp>) #s(irony-iotask-result error nil irony-iotask-bad-data (#0 "(error . (no-such-entry \"failed reset unsaved buffer\" \"/tmp/abcd.cpp\")
>
> ;;EOT
")) nil #s(irony-iotask-packaged-task (:start (lambda (file compile-options) (apply (function irony--server-send-command) "parse" file "--" compile-options)) :update irony--server-command-update) ("/tmp/abcd.cpp" ("-x" "c++")) #s(irony-iotask-result nil nil nil nil) nil #s(irony-iotask-packaged-task (:start (lambda nil (irony--server-send-command "diagnostics")) :update irony--server-query-update) nil #s(irony-iotask-result nil nil nil nil) nil nil))), "(error . (no-such-entry \"failed reset unsaved buffer\" \"/tmp/abcd.cpp\")
>
> ;;EOT
> "

And the Irony log file has the following content:
> execute: Command{action=Command::Parse, file='/var/folders/qd/dqf8z3ss0_l118qsqyrm81140000gn/T//irony-server-0895e5', unsavedFile='', dir='', line=0, column=0, prefix='', caseStyle='exact', flags=['-x', 'c++'], opt=off}
> execute: Command{action=Command::Diagnostics, file='', unsavedFile='', dir='', line=0, column=0, prefix='', caseStyle='exact', flags=[], opt=off}
> execute: Command{action=Command::SetUnsaved, file='/var/folders/qd/dqf8z3ss0_l118qsqyrm81140000gn/T//irony-server-0895e5', unsavedFile='/var/folders/qd/dqf8z3ss0_l118qsqyrm81140000gn/T/irony-unsaved-HJLctH', dir='', line=0, column=0, prefix='', caseStyle='exact', flags=[], opt=off}
> execute: Command{action=Command::Complete, file='/var/folders/qd/dqf8z3ss0_l118qsqyrm81140000gn/T//irony-server-0895e5', unsavedFile='', dir='', line=1, column=2, prefix='', caseStyle='exact', flags=['-x', 'c++'], opt=off}
> execute: Command{action=Command::Candidates, file='', unsavedFile='', dir='', line=0, column=0, prefix='inc', caseStyle='case-insensitive', flags=[], opt=off}
> execute: Command{action=Command::SetUnsaved, file='/var/folders/qd/dqf8z3ss0_l118qsqyrm81140000gn/T//irony-server-0895e5', unsavedFile='/var/folders/qd/dqf8z3ss0_l118qsqyrm81140000gn/T/irony-unsaved-rzrZZT', dir='', line=0, column=0, prefix='', caseStyle='exact', flags=[], opt=off}
> execute: Command{action=Command::Parse, file='/var/folders/qd/dqf8z3ss0_l118qsqyrm81140000gn/T//irony-server-0895e5', unsavedFile='', dir='', line=0, column=0, prefix='', caseStyle='exact', flags=['-x', 'c++'], opt=off}
> execute: Command{action=Command::Diagnostics, file='', unsavedFile='', dir='', line=0, column=0, prefix='', caseStyle='exact', flags=[], opt=off}
> execute: Command{action=Command::ResetUnsaved, file='/tmp/abcd.cpp', unsavedFile='', dir='', line=0, column=0, prefix='', caseStyle='exact', flags=[], opt=off}

## My Analysis
When a buffer is not backed by a file on disk, `irony--buffer-state-compare` returns `set-unsaved`, and `irony--buffer-state-compare` will send `set-unsaved` to the server, using `-` as the file name. Kind of a hack here to make sure nothing is really done, since there is no file anyway.
But the first time it is saved, the new state says the file is now unmodified, but was modified before. So the condition falls into the last case, and sends a `reset-unsaved` to the server. The server tries to remove the item from a map, but finding none, hence the error.
I added the check to make sure that only when old file exists, and the file changed from modified to unmodified, do we send `reset-unsaved` to the server.

I'm not sure if I misunderstood the semantics of `unsaved` and broke some other stuff though.