### PR TITLE
Allow public interactive function to parse current buffer

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -902,11 +902,11 @@ old-state can be nil if the old state isn't known."
         (message "%s (aka '%s')" (car types) (cadr types))
       (message "%s" (car types)))))
 
-(defun irony-parse-buffer-async (callback)
-  "Parse the current buffer sending the results to CALLBACK."
-  (interactive)
+(defun irony-parse-buffer-async (&optional callback)
+  "Parse the current buffer sending results to an optional
+  CALLBACK function."
   (irony--run-task-asynchronously (irony--parse-task)
-                                  callback))
+                                  (or callback #'ignore)))
 
 (provide 'irony)
 

--- a/irony.el
+++ b/irony.el
@@ -902,6 +902,12 @@ old-state can be nil if the old state isn't known."
         (message "%s (aka '%s')" (car types) (cadr types))
       (message "%s" (car types)))))
 
+(defun irony-parse-buffer ()
+  "Parse the current buffer."
+  (interactive)
+  (irony--run-task-asynchronously (irony--parse-task)
+                                  (lambda (result) ())))
+
 (provide 'irony)
 
 ;; Local Variables:

--- a/irony.el
+++ b/irony.el
@@ -903,7 +903,7 @@ old-state can be nil if the old state isn't known."
       (message "%s" (car types)))))
 
 (defun irony-parse-buffer-async (callback)
-  "Parse the current buffer sending the results to CALLBACK"
+  "Parse the current buffer sending the results to CALLBACK."
   (interactive)
   (irony--run-task-asynchronously (irony--parse-task)
                                   callback))

--- a/irony.el
+++ b/irony.el
@@ -902,11 +902,11 @@ old-state can be nil if the old state isn't known."
         (message "%s (aka '%s')" (car types) (cadr types))
       (message "%s" (car types)))))
 
-(defun irony-parse-buffer ()
-  "Parse the current buffer."
+(defun irony-parse-buffer-async (callback)
+  "Parse the current buffer sending the results to CALLBACK"
   (interactive)
   (irony--run-task-asynchronously (irony--parse-task)
-                                  (lambda (result) ())))
+                                  callback))
 
 (provide 'irony)
 


### PR DESCRIPTION
There have been a number of people who have come across a situation where restarting the server would be useful. 

For instance, after a while the completion results can return trash and I have never looked into why this is yet!

Anyway, at work I restart irony-server every 120s. I needed to create a function to allow this to happen and I think other people would find it useful if creating emacs timers.