### PR TITLE
Add 6.0.1 to clang known versions

### DIFF
--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -16,7 +16,7 @@
 # most recent versions come first
 # http://llvm.org/apt/
 set(LIBCLANG_KNOWN_LLVM_VERSIONS 7.0.0 7.0 7
-  6.0.0 6.0 6
+  6.0.0 6.0.1 6.0 6
   5.0.2 5.0.1 5.0.0 5.0 5
   4.0.1 4.0.0 4.0 4
   3.9.1 3.9.0 3.9


### PR DESCRIPTION
The latest unstable clang for Gentoo is 6.0.1, adding this allows stddef.h to be found.