### PR TITLE
irony-cdb-json/irony-server: Caches last used compilation database

### DIFF
--- a/server/src/CMakeLists.txt
+++ b/server/src/CMakeLists.txt
@@ -27,6 +27,8 @@ add_executable(irony-server
   Command.cpp
   Commands.def
   Command.h
+  CompDBCache.h
+  CompDBCache.cpp
   Irony.cpp
   Irony.h
   TUManager.cpp

--- a/server/src/CompDBCache.cpp
+++ b/server/src/CompDBCache.cpp
@@ -1,0 +1,71 @@
+#include "CompDBCache.h"
+
+#include <sys/stat.h>
+
+#include <cassert>
+
+CompDBCache::CompDBCache()
+  : db_(nullptr), mtime_(0) {
+}
+
+CompDBCache::~CompDBCache() {
+  clear();
+}
+
+CXCompilationDatabase CompDBCache::fromDirectory(const std::string &buildDir,
+                                                 CXCompilationDatabase_Error *error) {
+  assert(error != nullptr);
+
+  const std::string jsonFilename = constructJsonDbFilename(buildDir);
+  const time_t mtime = modificationTime(jsonFilename);
+
+  if (jsonFilename == filename_ && mtime != 0 && mtime == mtime_) {
+    // Using the cached compilation database.
+    // Just set the provided error code to indicate success.
+    *error = CXCompilationDatabase_NoError;
+  } else {
+    clear();
+
+    db_ = clang_CompilationDatabase_fromDirectory(buildDir.c_str(), error);
+
+    if (mtime != 0 && *error == CXCompilationDatabase_NoError) {
+      // Successfully loaded a JSON compilation database.
+      // Cache the result.
+      filename_ = jsonFilename;
+      mtime_ = mtime;
+    }
+  }
+
+  return db_;
+}
+
+void CompDBCache::clear() {
+  if (db_) {
+    clang_CompilationDatabase_dispose(db_);
+    db_ = nullptr;
+    filename_.clear();
+    mtime_ = 0;
+  }
+}
+
+std::string CompDBCache::constructJsonDbFilename(const std::string &buildDir) const {
+  std::string ret = buildDir;
+  if (!buildDir.empty() && buildDir.back() != '/')
+    ret += '/';
+  ret += "compile_commands.json";
+  return ret;
+}
+
+time_t CompDBCache::modificationTime(const std::string &filename) const {
+  time_t mtime = 0;
+#ifdef _WIN32
+  struct _stat st;
+  const int statRes = _stat(filename.c_str(), &st);
+#else
+  struct stat st;
+  const int statRes = stat(filename.c_str(), &st);
+#endif
+  if (statRes == 0)
+    mtime = st.st_mtime;
+  return mtime;
+}

--- a/server/src/CompDBCache.h
+++ b/server/src/CompDBCache.h
@@ -1,0 +1,86 @@
+/**-*-C++-*-
+ * \file
+ * \author Idar Tollefsen <idart@hotmail.com>
+ *
+ * \brief Creates a compilation database and caches it.
+ *
+ * Keeps a cache of the loaded compilation database, only creating a new
+ * one when needed.
+ *
+ * This file is distributed under the GNU General Public License.
+ * See COPYING for details.
+ */
+
+#ifndef IRONY_MODE_COMPDBCACHE_H_
+#define IRONY_MODE_COMPDBCACHE_H_
+
+#include "support/CIndex.h"
+#include "support/NonCopyable.h"
+
+#include <ctime>
+#include <string>
+
+class CompDBCache : public util::NonCopyable {
+public:
+  CompDBCache();
+  ~CompDBCache();
+
+  /**
+   * \brief Get a compilation database from a database found in a directory.
+   *
+   * This in essence a wrapper around
+   * \c clang_CompilationDatabase_fromDirectory() with added caching.
+   * It will either create a new compilation database or return the
+   * already loaded one (if any).
+   *
+   * This class owns the resulting compilation database.
+   * Therefore, unlike \c clang_CompilationDatabase_fromDirectory(),
+   * callers must NOT call \c clang_CompilationDatabase_dispose() on the
+   * returned compilation database. This class will handle that internally.
+   *
+   * \param buildDir Directory containing the database (such as
+   *                 "compile_commands.json") to create a compilation
+   *                 database from.
+   * \param error Error code from attempting to create a compilation
+   *              database (\c CXCompilationDatabase_NoError on success).
+   *
+   * \return The compilation database or nullptr.
+   */
+  CXCompilationDatabase fromDirectory(const std::string &buildDir,
+                                      CXCompilationDatabase_Error *error);
+
+private:
+  /**
+   * \brief Clear the cache.
+   *
+   * This will dispose the currently loaded compilation database (if any) by
+   * calling \c clang_CompilationDatabase_dispose() on it. And it will reset
+   * other internal housekeeping variables related to the caching of the
+   * compilation database.
+   */
+  void clear();
+
+  /**
+   * \brief Construct JSON compilation database filename.
+   *
+   * \param buildDir Directory that might contain "compile_commands.json".
+   *
+   * \return Path to "compilation_commands.json" in \c buildDir.
+   */
+  std::string constructJsonDbFilename(const std::string &buildDir) const;
+
+  /**
+   * \brief Get modification time of a file.
+   *
+   * \param filename The file to get last modification time of.
+   *
+   * \return The modification time of \c filename or 0.
+   */
+  time_t modificationTime(const std::string &filename) const;
+
+  CXCompilationDatabase db_;
+  std::string filename_;
+  time_t mtime_;
+};
+
+#endif

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -598,7 +598,7 @@ void Irony::getCompileOptions(const std::string &buildDir,
 #else
   CXCompilationDatabase_Error error;
   CXCompilationDatabase db =
-      clang_CompilationDatabase_fromDirectory(buildDir.c_str(), &error);
+      compDBCache_.fromDirectory(buildDir.c_str(), &error);
 
   switch (error) {
   case CXCompilationDatabase_CanNotLoadDatabase:
@@ -646,6 +646,5 @@ void Irony::getCompileOptions(const std::string &buildDir,
   std::cout << "))\n";
 
   clang_CompileCommands_dispose(compileCommands);
-  clang_CompilationDatabase_dispose(db);
 #endif
 }

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -18,6 +18,7 @@
 
 #include "TUManager.h"
 
+#include "CompDBCache.h"
 #include "Style.h"
 
 #include <string>
@@ -133,6 +134,7 @@ private:
   void computeCxUnsaved();
 
 private:
+  mutable CompDBCache compDBCache_;
   TUManager tuManager_;
   std::map<std::string, UnsavedBuffer> filenameToContent_;
   CXTranslationUnit activeTu_;


### PR DESCRIPTION
A compilation database can be very large and take a long time to read
and parse, which happens quite frequently (when opening a file for
instance).

This caches the last read/parsed compilation database based on its
filename and last modification time.

This could be extended to cache N number of databases instead of just
one, which would be useful when working on multiple projects
simultaneously.