### PR TITLE
Implement the main part of the xref interface

### DIFF
--- a/irony-xref.el
+++ b/irony-xref.el
@@ -143,5 +143,14 @@
 ;;      collect
 ;;      (xref-make name (xref-make-file-location filename line column)))))
 
+
+;; Setting up xref
+
+(defun irony-xref--enter ()
+  (add-hook 'xref-backend-functions #'irony--xref-backend nil t))
+
+(defun irony-xref--exit ()
+  (remove-hook 'xref-backend-functions #'irony--xref-backend t))
+
 (provide 'irony-xref)
 ;;; irony-xref.el ends here

--- a/irony-xref.el
+++ b/irony-xref.el
@@ -6,6 +6,11 @@
 ;;
 ;;     (add-hook 'irony-mode-hook (lambda () (add-hook 'xref-backend-functions #'irony--xref-backend nil t)))
 ;;
+;; Features:
+;; - will jump into system headers
+;; - with overloaded functions, will jump to the right function definition
+;;   (it's not just string matching on the function name)
+;;
 ;; Missing commands:
 ;; - ‘xref-find-apropos’
 ;;

--- a/irony-xref.el
+++ b/irony-xref.el
@@ -39,11 +39,6 @@
            (irony--server-send-command "xref-references" line col))
   :update irony--server-query-update)
 
-;; (irony-iotask-define-task irony--t-find-apropos
-;;   "`xref-apropos' server command."
-;;   :start (lambda (what) (irony--server-send-command "xref-apropos" what))
-;;   :update irony--server-query-update)
-
 
 ;;
 ;; Functions
@@ -96,7 +91,6 @@
          (line-column (irony--completion-line-column start))
          (thing (buffer-substring-no-properties start end)))
     (put-text-property 0 (length thing) 'irony-xref (list file buffer start end) thing)
-    ;; (message "xref-backend-identifier-at-point: %S" thing)
     thing))
 
 (cl-defmethod xref-backend-definitions ((_backend (eql irony)) identifier)
@@ -105,7 +99,7 @@
        (buffer (nth 1 thing))
        (line-column (irony--completion-line-column (nth 2 thing)))
        (result
-        ;; FIXME Must this be synchronous
+        ;; FIXME Must this be synchronous?
         (irony--run-task
          (irony-iotask-chain
           (irony--parse-task buffer)
@@ -114,9 +108,7 @@
     (cl-loop
      for (kind name filename line column start end) in result
      collect
-     (xref-make (concat name "(" (symbol-name kind) ")") (xref-make-file-location filename line column))
-     ;; do (message "result: %S" (list kind name filename line column start end))
-     )))
+     (xref-make (concat name "(" (symbol-name kind) ")") (xref-make-file-location filename line column)))))
 
 (cl-defmethod xref-backend-references ((_backend (eql irony)) identifier)
   (-when-let*
@@ -124,7 +116,7 @@
        (buffer (nth 1 thing))
        (line-column (irony--completion-line-column (nth 2 thing)))
        (result
-        ;; FIXME Must this be synchronous
+        ;; FIXME Must this be synchronous?
         (irony--run-task
          (irony-iotask-chain
           (irony--parse-task buffer)
@@ -133,20 +125,7 @@
     (cl-loop
      for (kind name filename line column start end) in result
      collect
-     (xref-make name (xref-make-file-location filename line column))
-     ;; do (message "result: %S" (list kind name filename line column start end))
-     )))
-
-;; (cl-defmethod xref-backend-apropos ((_backend (eql irony)) pattern)
-;;   (let ((result
-;;         ;; FIXME Must this be synchronous
-;;          (irony--run-task
-;;           (irony-iotask-package-task irony--t-find-apropos pattern))))
-;;     (dolist (item result) (message "xref-backend-apropos: %S" item))
-;;     (cl-loop
-;;      for (kind name filename line column start end) in result
-;;      collect
-;;      (xref-make name (xref-make-file-location filename line column)))))
+     (xref-make name (xref-make-file-location filename line column)))))
 
 
 ;; Setting up xref

--- a/irony-xref.el
+++ b/irony-xref.el
@@ -1,0 +1,119 @@
+;;; irony-xref.el --- Irony xref interface
+;;
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'irony)
+(require 'irony-completion)
+
+(require 'xref)
+(require 'dash)
+
+
+;;
+;; IO tasks
+;;
+
+(irony-iotask-define-task irony--t-find-definitions
+  "`xref' server command."
+  :start (lambda (line col)
+           (irony--server-send-command "xref" line col))
+  :update irony--server-query-update)
+
+(irony-iotask-define-task irony--t-find-references
+  "`grep' server command."
+  :start (lambda (line col)
+           (irony--server-send-command "grep" line col))
+  :update irony--server-query-update)
+
+
+;;
+;; Functions
+;;
+
+;;;###autoload
+(defun irony-find-definitions (&optional pos)
+  (interactive)
+  (let* ((line-column (irony--completion-line-column pos))
+         (line (car line-column))
+         (column (cdr line-column)))
+    (irony--run-task
+     (irony-iotask-chain
+      (irony--parse-task)
+      (irony-iotask-package-task irony--t-find-definitions line column)))))
+
+;;;###autoload
+(defun irony-find-references (&optional pos)
+  (interactive)
+  (let* ((line-column (irony--completion-line-column pos))
+         (result (irony--run-task
+                  (irony-iotask-chain
+                   (irony--parse-task)
+                   (irony-iotask-package-task irony--t-find-references
+                                              (car line-column) (cdr line-column))))))
+    (cl-loop for item in result
+             do (message "%S" item))))
+
+
+;;
+;; Xref backend
+;;
+
+;;;###autoload
+(defun irony--xref-backend () 'irony)
+
+;; (add-hook 'irony-mode (lambda () (add-hook 'xref-backend-functions #'irony--xref-backend nil t)))
+
+(cl-defmethod xref-backend-identifier-at-point ((_backend (eql irony)))
+  ;; FIXME These propertized strings are not suitable for completion
+  ;; FIXME which xref asks for
+  (let* ((bounds (irony-completion-symbol-bounds))
+         (start (car bounds))
+         (end (cdr bounds))
+         ;; FIXME Is (buffer-file-name) the right thing here?
+         (file (buffer-file-name))
+         (buffer (current-buffer))
+         (line-column (irony--completion-line-column start))
+         (thing (buffer-substring-no-properties start end)))
+    (put-text-property 0 (length thing) 'irony-xref (list file buffer start end) thing)
+    thing))
+
+(cl-defmethod xref-backend-definitions ((_backend (eql irony)) identifier)
+  (-when-let*
+      ((thing (get-text-property 0 'irony-xref identifier))
+       (buffer (nth 1 thing))
+       (line-column (irony--completion-line-column (nth 2 thing)))
+       (result
+        ;; Must be synchronous
+        (irony--run-task
+         (irony-iotask-chain
+          (irony--parse-task buffer)
+          (irony-iotask-package-task irony--t-find-definitions
+                                     (car line-column) (cdr line-column))))))
+    (cl-loop
+     for (kind name filename line column start end) in result
+     collect
+     (xref-make name (xref-make-file-location filename line column))
+     do (message "result: %S" (list kind name filename line column start end)))))
+
+(cl-defmethod xref-backend-references ((_backend (eql irony)) identifier)
+  (-when-let*
+      ((thing (get-text-property 0 'irony-xref identifier))
+       (buffer (nth 1 thing))
+       (line-column (irony--completion-line-column (nth 2 thing)))
+       (result
+        ;; Must be synchronous
+        (irony--run-task
+         (irony-iotask-chain
+          (irony--parse-task buffer)
+          (irony-iotask-package-task irony--t-find-references
+                                     (car line-column) (cdr line-column))))))
+    (cl-loop
+     for (kind name filename line column start end) in result
+     collect
+     (xref-make name (xref-make-file-location filename line column))
+     do (message "result: %S" (list kind name filename line column start end)))))
+
+(provide 'irony-xref)
+;;; irony-xref.el ends here

--- a/irony.el
+++ b/irony.el
@@ -47,10 +47,11 @@
 ;;; Code:
 
 (require 'irony-iotask)
-(require 'irony-xref)
 
 (autoload 'irony-completion--enter "irony-completion")
 (autoload 'irony-completion--exit "irony-completion")
+(autoload 'irony-xref--enter "irony-xref")
+(autoload 'irony-xref--exit "irony-xref")
 
 (require 'cl-lib)
 

--- a/irony.el
+++ b/irony.el
@@ -47,6 +47,7 @@
 ;;; Code:
 
 (require 'irony-iotask)
+(require 'irony-xref)
 
 (autoload 'irony-completion--enter "irony-completion")
 (autoload 'irony-completion--exit "irony-completion")
@@ -426,6 +427,7 @@ If no such file exists on the filesystem the special file '-' is
       (display-warning 'irony "Performance will be bad because a\
  pipe delay is set for this platform (see variable\
  `w32-pipe-read-delay')."))))
+  (irony-xref--enter)
   (irony-completion--enter))
 
 (defun irony--mode-exit ()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -14,6 +14,8 @@ include(CTest)
 check_for_in_source_build()
 release_as_default_build_type()
 
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fsanitize=address -fsanitize=undefined -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-missing-prototypes -Wno-shadow-field-in-constructor")
+
 # Disable exception, we aren't using them and right now clang-cl needs them
 # disabled to parse Windows headers.
 #

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -188,6 +188,16 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
   std::vector<std::function<bool(const std::string &)>> positionalArgs;
 
   switch (command_.action) {
+  case Command::Xref:
+    positionalArgs.push_back(UnsignedIntConverter(&command_.line));
+    positionalArgs.push_back(UnsignedIntConverter(&command_.column));
+    break;
+
+  case Command::Grep:
+    positionalArgs.push_back(UnsignedIntConverter(&command_.line));
+    positionalArgs.push_back(UnsignedIntConverter(&command_.column));
+    break;
+
   case Command::SetDebug:
     positionalArgs.push_back(OptionConverter(&command_.opt));
     break;

--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -188,12 +188,12 @@ Command *CommandParser::parse(const std::vector<std::string> &argv) {
   std::vector<std::function<bool(const std::string &)>> positionalArgs;
 
   switch (command_.action) {
-  case Command::Xref:
+  case Command::XrefDefinitions:
     positionalArgs.push_back(UnsignedIntConverter(&command_.line));
     positionalArgs.push_back(UnsignedIntConverter(&command_.column));
     break;
 
-  case Command::Grep:
+  case Command::XrefReferences:
     positionalArgs.push_back(UnsignedIntConverter(&command_.line));
     positionalArgs.push_back(UnsignedIntConverter(&command_.column));
     break;

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -15,8 +15,8 @@
 X(Candidates, "candidates",
   "PREFIX STYLE - print completion candidates (require previous complete). "
   "STYLE is \"exact\", \"case-insensitive\" or \"smart-case\"")
-X(Xref, "xref", "LINE COL - print definition/reference of what is at the given location")
-X(Grep, "grep", "LINE COL - print all uses of what is at the given location")
+X(XrefDefinitions, "xref-definitions", "LINE COL - print definition/reference")
+X(XrefReferences, "xref-references", "LINE COL - print all uses")
 X(Complete, "complete",
   "FILE LINE COL [-- [COMPILE_OPTIONS...]] - perform code completion at a given location")
 X(CompletionDiagnostics, "completion-diagnostics",

--- a/server/src/Commands.def
+++ b/server/src/Commands.def
@@ -15,6 +15,8 @@
 X(Candidates, "candidates",
   "PREFIX STYLE - print completion candidates (require previous complete). "
   "STYLE is \"exact\", \"case-insensitive\" or \"smart-case\"")
+X(Xref, "xref", "LINE COL - print definition/reference of what is at the given location")
+X(Grep, "grep", "LINE COL - print all uses of what is at the given location")
 X(Complete, "complete",
   "FILE LINE COL [-- [COMPILE_OPTIONS...]] - perform code completion at a given location")
 X(CompletionDiagnostics, "completion-diagnostics",

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -678,7 +678,7 @@ void Irony::getCompileOptions(const std::string &buildDir,
 
 void Irony::xrefDefinitions(unsigned line, unsigned col) const {
   if (activeTu_ == nullptr) {
-    std::clog << "W: get-type - parse wasn't called\n";
+    std::clog << "W: xref-definitions - parse wasn't called\n";
     std::cout << "nil" << std::endl;
     return;
   }
@@ -702,7 +702,7 @@ void Irony::xrefDefinitions(unsigned line, unsigned col) const {
 
 void Irony::xrefReferences(unsigned line, unsigned col) const {
   if (activeTu_ == nullptr) {
-    std::clog << "W: get-type - parse wasn't called\n";
+    std::clog << "W: xref-references - parse wasn't called\n";
     std::cout << "nil\n";
     return;
   }

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -123,7 +123,7 @@ void prettyPrintCursor(std::string label, CXCursor cursor) {
   CXString name = clang_getCursorDisplayName(cursor);
   CXSourceRange loc = clang_getCursorExtent(cursor);
   CXSourceLocation start = clang_getRangeStart(loc),
-    end = clang_getRangeEnd(loc);
+                   end = clang_getRangeEnd(loc);
   CXFile file;
   unsigned start_line, start_col, start_offset, end_offset;
   clang_getSpellingLocation(start, &file, &start_line, &start_col,
@@ -134,9 +134,9 @@ void prettyPrintCursor(std::string label, CXCursor cursor) {
   // FIXME But there doesn’t seem to be a clear way to do it without going
   // FIXME throught the whole AST.
   std::cout << "(" << label << " " << support::quoted(clang_getCString(name))
-           << " " << support::quoted(clang_getCString(filename)) << " "
-           << start_line << " " << start_col << " " << start_offset << " "
-           << end_offset << ")\n";
+            << " " << support::quoted(clang_getCString(filename)) << " "
+            << start_line << " " << start_col << " " << start_offset << " "
+            << end_offset << ")\n";
   clang_disposeString(name);
   clang_disposeString(filename);
 }

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -109,8 +109,15 @@ public:
   /// \pre complete() was called.
   void completionDiagnostics() const;
 
-  void xref(unsigned line, unsigned col) const;
-  void grep(unsigned line, unsigned col) const;
+  /// Lookup definition/declaration of the given symbol.
+  ///
+  /// \pre parse() was called.
+  void xrefDefinitions(unsigned line, unsigned col) const;
+
+  /// Get all references to the given symbol.
+  ///
+  /// \pre parse() was called
+  void xrefReferences(unsigned line, unsigned col) const;
 
   /// \brief Get compile options from JSON database.
   ///

--- a/server/src/Irony.h
+++ b/server/src/Irony.h
@@ -109,6 +109,9 @@ public:
   /// \pre complete() was called.
   void completionDiagnostics() const;
 
+  void xref(unsigned line, unsigned col) const;
+  void grep(unsigned line, unsigned col) const;
+
   /// \brief Get compile options from JSON database.
   ///
   /// \param buildDir Directory containing compile_commands.json

--- a/server/src/TUManager.h
+++ b/server/src/TUManager.h
@@ -82,6 +82,11 @@ public:
    */
   void invalidateAllCachedTUs();
 
+  const std::map<const std::string, CXTranslationUnit>
+  allAvailableTranslationUnits() const {
+    return translationUnits_;
+  }
+
 private:
   /**
    * \brief Get a reference to the translation unit that matches \p filename

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -176,6 +176,14 @@ int main(int ac, const char *av[]) {
     }
 
     switch (c->action) {
+    case Command::Xref:
+      irony.xref(c->line, c->column);
+      break;
+
+    case Command::Grep:
+      irony.grep(c->line, c->column);
+      break;
+
     case Command::Help:
       printHelp();
       break;

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -176,12 +176,12 @@ int main(int ac, const char *av[]) {
     }
 
     switch (c->action) {
-    case Command::Xref:
-      irony.xref(c->line, c->column);
+    case Command::XrefDefinitions:
+      irony.xrefDefinitions(c->line, c->column);
       break;
 
-    case Command::Grep:
-      irony.grep(c->line, c->column);
+    case Command::XrefReferences:
+      irony.xrefReferences(c->line, c->column);
       break;
 
     case Command::Help:


### PR DESCRIPTION
I left for a while and completely forgot #384.

For the xref interface see https://github.com/emacs-mirror/emacs/blob/master/lisp/progmodes/xref.el, and the lisp xref backend in https://github.com/emacs-mirror/emacs/blob/master/lisp/progmodes/elisp-mode.el

This implements `xref-find-{definitions,references}`. It's not quite perfect
- it will jump into system headers (not sure if this is good or not, I've been using it that way myself)
- it will resolve a call of an overloaded function to the right definition
- The `find-references` functionality seems a little wonky: it seems to find references to the thing at point only in the same file plus the file in which it is defined (?). Maybe I got the AST traversal logic wrong in `Irony::xrefReferences`, but I'm not sure.

There a several FIXME's left in the code, which may or may not be issues (please have a look), they were things I wasn't quite sure about.

I tested this in my own code, it seems to work, but I don't have any actual unit tests for it.