### PR TITLE
Add support for compile_flags.txt

### DIFF
--- a/irony-cdb-clang-complete.el
+++ b/irony-cdb-clang-complete.el
@@ -22,6 +22,11 @@
 ;;
 ;; This file defines a compilation database for .clang_complete file.
 ;;
+;; Another type of compilation database, compile_flags.txt
+;; (https://clang.llvm.org/docs/JSONCompilationDatabase.html#build-system-integration)
+;; appears to share a very similar format, so is processed the same
+;; way as a .clang_complete file.
+;;
 
 ;;; Code:
 

--- a/irony-cdb-clang-complete.el
+++ b/irony-cdb-clang-complete.el
@@ -40,8 +40,15 @@
 
 (defun irony-cdb-clang-complete--locate-db ()
   (when buffer-file-name
-    (irony--awhen (locate-dominating-file buffer-file-name ".clang_complete")
-      (concat (file-name-as-directory it) ".clang_complete"))))
+    (let ((clang-complete
+           (locate-dominating-file buffer-file-name ".clang_complete"))
+          (compile-flags
+           (locate-dominating-file buffer-file-name "compile_flags.txt")))
+      (or
+       (when clang-complete
+         (concat (file-name-as-directory clang-complete) ".clang_complete"))
+       (when compile-flags
+         (concat (file-name-as-directory compile-flags) "compile_flags.txt"))))))
 
 (defun irony-cdb-clang-complete--load-db (cc-file)
   (with-temp-buffer


### PR DESCRIPTION
See #489 

The format of compile_flags.txt appears to be compatible with the format of .clang_complete. If https://github.com/Rip-Rip/clang_complete has the right definition of the format, then it's the same one-flag-per-line type of thing.