### PR TITLE
FindLibClang.cmake: add support for 7.0.1

### DIFF
--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -16,7 +16,7 @@
 # most recent versions come first
 # http://llvm.org/apt/
 set(LIBCLANG_KNOWN_LLVM_VERSIONS 8.0.0 8.0 8
-  7.0.0 7.0 7
+  7.0.1 7.0.0 7.0 7
   6.0.1 6.0.0 6.0 6
   5.0.2 5.0.1 5.0.0 5.0 5
   4.0.1 4.0.0 4.0 4


### PR DESCRIPTION
Support 7.0.1 latest clang from ArchLinux repository