### PR TITLE
Look for irony-server in irony.el directory

### DIFF
--- a/irony.el
+++ b/irony.el
@@ -570,7 +570,10 @@ The installation requires CMake and the libclang developpement package."
 Throw an `irony-server-error' if a proper executable cannot be
 found."
   (let* ((exec-path (cons (expand-file-name "bin" irony-server-install-prefix)
-                          exec-path))
+                          (cons (expand-file-name "server/bin"
+                                                  (file-name-directory (or load-file-name
+                                                                           buffer-file-name)))
+                                exec-path)))
          (exe (executable-find "irony-server")))
     (condition-case err
         (let ((version (car (process-lines exe "--version"))))


### PR DESCRIPTION
This makes irony--find-server-executable look in
<load-file-name>/server/bin for the irony-server executable. This is
useful when you want the irony-server executable to be preinstalled
system-wide in your Emacs setup. This saves users the trouble of
having to individually build irony-server and have all of the
dependencies that come with it.