### PR TITLE
Follow symbolic links for filename comparison

### DIFF
--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -240,8 +240,8 @@ should be used since elements can change at the head.
 Removes the input file, the output file, ...
 
 Relative paths are relative to DEFAULT-DIR."
-  ;; compute the absolute path for FILE only once
-  (setq file (expand-file-name file default-dir))
+  ;; compute the truename of the absolute path for FILE only once
+  (setq file (file-truename (expand-file-name file default-dir)))
   (let* ((head (cons 'nah compile-options))
          (it head)
          opt)
@@ -258,8 +258,8 @@ Relative paths are relative to DEFAULT-DIR."
         (if (string= opt "-o")
             (setcdr it (nthcdr 3 it))
           (setcdr it (nthcdr 2 it))))
-       ;; skip input file
-       ((string= (file-truename file) (file-truename (expand-file-name opt default-dir)))
+       ;; skip input file; avoid invoking file commands if an option argument
+       ((and (not (string-prefix-p "-" opt)) (string= file (file-truename (expand-file-name opt default-dir))))
         (setcdr it (nthcdr 2 it)))
        (t
         ;; if head of cdr hasn't been skipped, iterate, otherwise check if the

--- a/irony-cdb-json.el
+++ b/irony-cdb-json.el
@@ -259,7 +259,7 @@ Relative paths are relative to DEFAULT-DIR."
             (setcdr it (nthcdr 3 it))
           (setcdr it (nthcdr 2 it))))
        ;; skip input file
-       ((string= file (expand-file-name opt default-dir))
+       ((string= (file-truename file) (file-truename (expand-file-name opt default-dir)))
         (setcdr it (nthcdr 2 it)))
        (t
         ;; if head of cdr hasn't been skipped, iterate, otherwise check if the


### PR DESCRIPTION
In a src tree with several symbolic links in paths the filenames did not always match.   At least with the waf build tool the real path name is appearing in the compile_commands.json file.  The compiler option parsing was failing to remove the src file.   Used file-truefilename to follow symbolic links for name comparison.