### PR TITLE
README: Add section about how to access newer versions of Clang/LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ package manager.
 * Using `apt` on Debian ≥10 and derivatives
 
         sudo apt install elpa-irony
+#### Accessing a newer Clang and LLVM Toolchain on Debian and derivatives
+The [backports](https://backports.debian.org/) mechanism is the
+recommended and officially supported method of accessing newer
+versions than `Debian stable` provides.
+
+        sudo apt install -t $release_name-backports elpa-irony
+
+If the llvm-toolchain backport is not new enough please use the
+following repository: [LLVM Debian/Ubuntu nightly
+packages.](https://apt.llvm.org) This repository is maintained by
+Sylvestre Ledru, who is responsible for the official Debian package.
+His repository also supports Ubuntu and derivatives.  When using
+this unofficial repository the MELPA package of irony-mode should be
+used in preference to the `elpa-irony` package.
 
 ## Configuration
 


### PR DESCRIPTION
Hi @Sarcasm,

The motivation for this PR is to document the best methods for Debian (and derivatives) users to use irony-mode with a newer version of Clang, both the officially supported and unsupported method.  I discussed #543 with the Sylvestre Ledru, and he recommends these users use his LLVM nightly repository, in case the stable version provided in backports wasn't new enough.  If you'd prefer not to merge it I'd be happy to maintain a patch against the Debian (and derivatives) package.  Please let me know if you prefer differently styled formatting, or feel free to make modification.

Cheers,
Nicholas