### PR TITLE
Revert change to Irony mode to patch a now fixed bug in Clang that has not existed since about version 9

### DIFF
--- a/irony-completion.el
+++ b/irony-completion.el
@@ -259,8 +259,10 @@ A candidate is composed of the following elements:
     more indices. These indices work by pairs and describe ranges
     of placeholder text.
     Example: (\"(int a, int b)\" 1 6 8 13)"
-  (and (irony-completion-candidates-available-p)
-       irony-completion--candidates))
+  (irony--awhen (irony-completion-symbol-bounds)
+    (irony-completion--filter-candidates
+     (irony--run-task
+      (irony--candidates-task nil (car it) prefix style)))))
 
 (defun irony-completion-candidates-async (callback &optional prefix style)
   (irony--aif (irony-completion-symbol-bounds)

--- a/irony-completion.el
+++ b/irony-completion.el
@@ -57,19 +57,6 @@
   :type '(repeat function)
   :group 'irony-completion)
 
-(defcustom irony-completion-availability-filter '(available deprecated)
- "For completion, only accept candidates whose availability is in the list.
-
-Maps to libclang's CXAvailabilityKind:
-- https://clang.llvm.org/doxygen/group__CINDEX.html#gada331ea0195e952c8f181ecf15e83d71
-
-Due to a bug in
-Clang (https://bugs.llvm.org//show_bug.cgi?id=24329), candidates
-that can be validly accessed are deemed not-accessible."
- :type '(repeat symbol)
- :options '(available deprecated not-accessible)
- :group 'irony-completion)
-
 (defcustom irony-duplicate-candidates-filter nil
   "Remove duplicate candidates.
 
@@ -234,10 +221,6 @@ displayed when a derived class overrides virtual methods."
 (defun irony-completion-post-comp-placeholders (candidate)
   (cdr (nth 6 candidate)))
 
-(defun irony-completion-availability (candidate)
-  "See `irony-completion-availability-filter'"
-  (nth 7 candidate))
-
 (defun irony-completion--filter-candidates (candidates)
   "Filter candidates based on availability (CXAvailabilityKind)
 first then remove any duplicates. Duplicate candidates are those
@@ -276,12 +259,9 @@ A candidate is composed of the following elements:
  6. Post-completion data. The text to insert followed by 0 or
     more indices. These indices work by pairs and describe ranges
     of placeholder text.
-    Example: (\"(int a, int b)\" 1 6 8 13)
- 7. The availability (CXAvailabilityKind) of the candidate." 
-  (irony--awhen (irony-completion-symbol-bounds)
-    (irony-completion--filter-candidates
-     (irony--run-task
-      (irony--candidates-task nil (car it) prefix style)))))
+    Example: (\"(int a, int b)\" 1 6 8 13)"
+  (and (irony-completion-candidates-available-p)
+       irony-completion--candidates))
 
 (defun irony-completion-candidates-async (callback &optional prefix style)
   (irony--aif (irony-completion-symbol-bounds)

--- a/irony-completion.el
+++ b/irony-completion.el
@@ -222,25 +222,24 @@ displayed when a derived class overrides virtual methods."
   (cdr (nth 6 candidate)))
 
 (defun irony-completion--filter-candidates (candidates)
-  "Filter candidates based on availability (CXAvailabilityKind)
-first then remove any duplicates. Duplicate candidates are those
-that have the same `irony-completion-typed-text',
-`irony-completion-annotation' and `irony-completion-type'. An
-example of when this is useful is when there are many derived
-classes that override a virtual method resulting in redundant
-duplicate entries being displayed in the list of completions."
+  "Filter candidates by removing duplicates if
+`irony-duplicate-candidates-filter' is non nil; Duplicate
+candidates are those that have the same
+`irony-completion-typed-text', `irony-completion-annotation' and
+`irony-completion-type'. An example of when this is useful is
+when there are many derived classes that override a virtual
+method resulting in redundant duplicate entries being displayed
+in the list of completions."
   (let (unique-candidates)
     (cl-remove-if-not
      (lambda (candidate)
-       (and (memq (irony-completion-availability candidate)
-		   irony-completion-availability-filter)
-            (or (not irony-duplicate-candidates-filter)
-                (let ((unique-key (list (irony-completion-typed-text candidate)
-                                        (irony-completion-annotation candidate)
-                                        (irony-completion-type candidate))))
-                  (and (not (member unique-key unique-candidates))
-                       (push unique-key unique-candidates))))))
-     candidates)))
+       (or (not irony-duplicate-candidates-filter)
+           (let ((unique-key (list (irony-completion-typed-text candidate)
+                                   (irony-completion-annotation candidate)
+                                   (irony-completion-type candidate))))
+             (and (not (member unique-key unique-candidates))
+                  (push unique-key unique-candidates))))))
+    candidates))
 
 (defun irony-completion-candidates (&optional prefix style)
   "Return the list of candidates at point.

--- a/server/src/Irony.cpp
+++ b/server/src/Irony.cpp
@@ -372,7 +372,7 @@ void Irony::candidates(const std::string &prefix, PrefixMatchStyle style) const 
   std::cout << "(\n";
 
   // re-use the same buffers to avoid unnecessary allocations
-  std::string typedtext, brief, resultType, prototype, postCompCar, available;
+  std::string typedtext, brief, resultType, prototype, postCompCar;
 
   std::vector<unsigned> postCompCdr;
 
@@ -387,29 +387,18 @@ void Irony::candidates(const std::string &prefix, PrefixMatchStyle style) const 
     bool typedTextSet = false;
     bool hasPrefix = true;
 
+
+    if (availability == CXAvailability_NotAccessible ||
+        availability == CXAvailability_NotAvailable) {
+      continue;
+    }
+    
     typedtext.clear();
     brief.clear();
     resultType.clear();
     prototype.clear();
     postCompCar.clear();
     postCompCdr.clear();
-    available.clear();
-
-    switch (availability) {
-    case CXAvailability_NotAvailable:
-      // No benefits to expose this to elisp for now
-      continue;
-
-    case CXAvailability_Available:
-      available = "available";
-      break;
-    case CXAvailability_Deprecated:
-      available = "deprecated";
-      break;
-    case CXAvailability_NotAccessible:
-      available = "not-accessible";
-      break;
-    }
 
     for (CompletionChunk chunk(candidate.CompletionString); chunk.hasNext();
          chunk.next()) {
@@ -519,7 +508,6 @@ void Irony::candidates(const std::string &prefix, PrefixMatchStyle style) const 
     for (unsigned index : postCompCdr)
       std::cout << ' ' << index;
     std::cout << ")"
-              << ' ' << available
               << ")\n";
   }
 


### PR DESCRIPTION
I finally have got around to removing the fix introduced to irony to display non-accessibles. Recall that before version 9 of LLVM/Clang (or around that time) **protected** members/methods were not showing in derived classes in completions due to a bug in LLVM/Clang.