### PR TITLE
Fixed list args error for irony-completion--filter-candidates

### DIFF
--- a/irony-completion.el
+++ b/irony-completion.el
@@ -238,8 +238,8 @@ in the list of completions."
                                    (irony-completion-annotation candidate)
                                    (irony-completion-type candidate))))
              (and (not (member unique-key unique-candidates))
-                  (push unique-key unique-candidates))))))
-    candidates))
+                  (push unique-key unique-candidates)))))
+     candidates)))
 
 (defun irony-completion-candidates (&optional prefix style)
   "Return the list of candidates at point.


### PR DESCRIPTION
@Sarcasm ,

Hello. I have fixed the issue with #569 and tested locally.

I used the following program to test:
```
#include <string>

struct MyClass0
{
	MyClass0( void ) { }
	~MyClass0( void ) { }
	virtual int theFunction( float x ) = 0;
	const std::string thisFunc( void ) const { }
	std::string thisFunc( void ) { }

	virtual const float overrideMe(void){}
	virtual float overrideMe(void) const {}
protected:
    std::string myProtected( void ) { return std::string( " HELLO! " ); };
};

struct MyClass1 : public MyClass0
{
	MyClass1( void ) : MyClass0() { }
	virtual ~MyClass1( void ) { }

	virtual int theFunction( float x ) override { (void)x; }
	virtual const float overrideMe(void) override { ; }
protected:
	int x;
};

struct MyClass2 : public MyClass1
{
	MyClass2( void ) : MyClass1() { }
	~MyClass2( void ) { }

	virtual int theFunction( float x ) override { (void)x; }

	void someOtherFn()
		{
            std::string x = myProtected();
            (void)x;
		}

	virtual float overrideMe( void ) const { ; }
};

int main( void )
{
	MyClass2 my_class_2;
	return 0;
}
```
It demonstrates that with Clang version 10 the "protected" bug is not a problem because I get completion for **myProtected()** inside **someOtherFn()**. https://bugs.llvm.org//show_bug.cgi?id=24329 (this is not marked as resolved on their end, but probably should be. There are no doubt duplicate issues)

It also demonstrates the continued need for my other merged pull-request (#503) about filtering out duplicates; the duplicate option continues to be disabled by default.

Merci.