### PR TITLE
Add missing include for GCC 11

### DIFF
--- a/server/src/Command.cpp
+++ b/server/src/Command.cpp
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <map>
 
 


### PR DESCRIPTION
Using GCC 11, I had to add an include for <limits> to bring in std::numeric_limits:

/external_sd/src/irony/0/src/server/src/Command.cpp: In member function 'bool {anonymous}::UnsignedIntConverter::operator()(const string&)':
/external_sd/src/irony/0/src/server/src/Command.cpp:53:21: error: 'numeric_limits' is not a member of 'std'
   53 |     if (unum > std::numeric_limits<unsigned>::max())
      |                     ^~~~~~~~~~~~~~
/external_sd/src/irony/0/src/server/src/Command.cpp:53:36: error: expected primary-expression before 'unsigned'
   53 |     if (unum > std::numeric_limits<unsigned>::max())
      |                                    ^~~~~~~~
/external_sd/src/irony/0/src/server/src/Command.cpp:53:36: error: expected ')' before 'unsigned'
/external_sd/src/irony/0/src/server/src/Command.cpp:53:8: note: to match this '('
   53 |     if (unum > std::numeric_limits<unsigned>::max())
      |        ^

Searching around, looks like a few other packages ran into the same issue, e.g. https://github.com/xtensor-stack/xsimd/pull/395

Thanks for the great package!

