### PR TITLE
Add option to disable when editing over tramp

### DIFF
--- a/irony-cdb.el
+++ b/irony-cdb.el
@@ -92,9 +92,12 @@ such as a custom named build directory.
 ;;;###autoload
 (defun irony-cdb-autosetup-compile-options ()
   (interactive)
-  (irony--awhen (irony-cdb--autodetect-compile-options)
-    (setq irony-cdb--compilation-database (nth 0 it))
-    (irony-cdb--update-compile-options (nth 1 it) (nth 2 it))))
+  (unless (and irony-disable-over-tramp
+               buffer-file-name
+               (file-remote-p buffer-file-name))
+    (irony--awhen (irony-cdb--autodetect-compile-options)
+      (setq irony-cdb--compilation-database (nth 0 it))
+      (irony-cdb--update-compile-options (nth 1 it) (nth 2 it)))))
 
 ;;;###autoload
 (defun irony-cdb-menu ()

--- a/irony.el
+++ b/irony.el
@@ -180,6 +180,9 @@ Larger values can improve performances on large buffers.
 If non-nil, `w32-pipe-buffer-size' will be let-bound to this value
 during the creation of the irony-server process.")
 
+(defcustom irony-disable-over-tramp nil
+  "Set to non-nil to disable when editing over tramp.")
+
 
 ;;
 ;; Public/API variables
@@ -390,7 +393,10 @@ If no such file exists on the filesystem the special file '-' is
   returned instead."
   (let ((file (buffer-file-name buffer)))
     (if (and file (file-exists-p file))
-        file
+        (if (and 'irony-disable-over-tramp
+                 (file-remote-p file))
+            "-"
+          file)
       "-")))
 
 

--- a/irony.el
+++ b/irony.el
@@ -393,7 +393,7 @@ If no such file exists on the filesystem the special file '-' is
   returned instead."
   (let ((file (buffer-file-name buffer)))
     (if (and file (file-exists-p file))
-        (if (and 'irony-disable-over-tramp
+        (if (and irony-disable-over-tramp
                  (file-remote-p file))
             "-"
           file)


### PR DESCRIPTION
This PR adds the ability to disable irony-mode when editing files over tramp (to prevent errors when irony tries to access files over tramp).

```elisp
(setq irony-disable-over-tramp t)
```

